### PR TITLE
AER correspondence

### DIFF
--- a/raft-proofs/AppendEntriesReplySublogProof.v
+++ b/raft-proofs/AppendEntriesReplySublogProof.v
@@ -7,6 +7,7 @@ Require Import Util.
 Require Import Raft.
 
 Require Import CommonTheorems.
+Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.
 
 Require Import UpdateLemmas.
@@ -14,11 +15,80 @@ Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import AppendEntriesReplySublogInterface.
 
+Require Import AppendEntriesRequestReplyCorrespondenceInterface.
+Require Import RaftRefinementInterface.
+Require Import AllEntriesLeaderLogsInterface.
+
 Section AppendEntriesReplySublog.
   Context {orig_base_params : BaseParams}.
   Context {one_node_params : OneNodeParams orig_base_params}.
   Context {raft_params : RaftParams orig_base_params}.
 
+  Context {aerrci : append_entries_request_reply_correspondence_interface}.
+  Context {rri : raft_refinement_interface}.
+  Context {aelli : all_entries_leader_logs_interface}.
+
+  Definition lowered_appendEntries_leader (net : @network _ multi_params)  :=
+    forall p t leaderId prevLogIndex prevLogTerm entries leaderCommit h e,
+      In p (nwPackets net) ->
+      pBody p = AppendEntries t leaderId prevLogIndex prevLogTerm
+                              entries leaderCommit ->
+      In e entries ->
+      currentTerm (nwState net h) = t ->
+      type (nwState net h) = Leader ->
+      In e (log (nwState net h)).
+
+  Theorem lower_appendEntries_leader :
+    forall net,
+      raft_intermediate_reachable net ->
+      lowered_appendEntries_leader net.
+  Proof.
+    intros.
+    apply (lower_prop lowered_appendEntries_leader); auto.
+    intros.
+    find_apply_lem_hyp all_entries_leader_logs_invariant.
+    unfold all_entries_leader_logs in *. intuition.
+    unfold lowered_appendEntries_leader, appendEntries_leader in *.
+    intros. simpl in *.
+    repeat break_match. simpl in *.
+    do_in_map. subst. simpl in *.
+    match goal with
+      | H : ?nwState  ?h = (?gd, ?d) |- _ =>
+        replace gd with (fst (nwState h)) in * by (rewrite H; reflexivity);
+          replace d with (snd (nwState h)) in * by (rewrite H; reflexivity);
+          clear H
+    end.
+    eapply_prop_hyp AppendEntries AppendEntries; eauto.
+  Qed.
+
+  Theorem append_entries_reply_sublog_invariant :
+    forall net,
+      raft_intermediate_reachable net ->
+      append_entries_reply_sublog net.
+  Proof.
+    unfold append_entries_reply_sublog. intros.
+    find_apply_lem_hyp append_entries_request_reply_correspondence_invariant.
+    eapply_prop_hyp append_entries_request_reply_correspondence AppendEntriesReply; eauto.
+    unfold exists_equivalent_network_with_aer in *.
+    break_exists_name net'. break_exists. intuition.
+    match goal with
+      | _ : nwPackets _ = _ ++ (mkPacket ?s ?d ?b) :: nil |- _ =>
+        remember (mkPacket s d b) as aer;
+          assert (pBody aer = b) by (subst; simpl; auto);
+          clear Heqaer
+    end.
+    match goal with
+      | H : In _ (nwPackets _) |- _ => clear H
+    end.
+    assert (In aer (nwPackets net')) by (repeat find_rewrite; intuition).
+    match goal with
+      | H : nwState net' = nwState net |- _ =>
+        rewrite <- H in *; clear H
+    end.
+    eapply lower_appendEntries_leader; eauto.
+  Qed.
+  
   Instance aersi : append_entries_reply_sublog_interface.
-  Admitted.
+  split. exact append_entries_reply_sublog_invariant.
+  Qed.
 End AppendEntriesReplySublog.

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -1,0 +1,431 @@
+Require Import List.
+Import ListNotations.
+Require Import Omega.
+Require Import FunctionalExtensionality.
+
+
+Require Import VerdiTactics.
+Require Import Net.
+Require Import Util.
+Require Import Raft.
+
+Require Import CommonTheorems.
+Require Import SpecLemmas.
+
+Require Import UpdateLemmas.
+Require Import DecompositionWithPostState.
+Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
+Require Import AppendEntriesRequestReplyCorrespondenceInterface.
+
+Section AppendEntriesRequestReplyCorrespondence.
+  Context {orig_base_params : BaseParams}.
+  Context {one_node_params : OneNodeParams orig_base_params}.
+  Context {raft_params : RaftParams orig_base_params}.
+
+  Lemma append_entries_request_reply_correspondence_init :
+    raft_net_invariant_init append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *. intuition.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_timeout :
+    raft_net_invariant_timeout append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto.
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli.
+      break_exists_name plt.
+      break_exists_name ci.
+      break_exists_name n.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
+      subst.
+      exists pli,plt,ci,n. simpl in *; intuition.
+      eapply RIR_handleInput with (net0 := net') (inp := Timeout); eauto;
+      simpl; repeat find_rewrite; eauto.
+      intros.
+      do_in_app. intuition.
+      find_apply_hyp_hyp.
+      intuition.
+    - exfalso.
+      do_in_map. subst. simpl in *.
+      unfold handleTimeout, tryToBecomeLeader in *.
+      repeat break_match; find_inversion; intuition; do_in_map; subst; simpl in *; congruence.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_client_request :
+    raft_net_invariant_client_request append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto.
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli.
+      break_exists_name plt.
+      break_exists_name ci.
+      break_exists_name n.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
+      subst.
+      exists pli,plt,ci,n. simpl in *; intuition.
+      eapply RIR_handleInput with (net0 := net') (inp := ClientRequest client id c); eauto;
+      simpl; repeat find_rewrite; eauto.
+      intros.
+      do_in_app. intuition.
+      find_apply_hyp_hyp.
+      intuition.
+    - exfalso.
+      do_in_map. subst. simpl in *.
+      unfold handleClientRequest in *.
+      repeat break_match; find_inversion; intuition; do_in_map; subst; simpl in *; congruence.
+  Qed.
+
+
+  Lemma append_entries_request_reply_correspondence_do_leader :
+    raft_net_invariant_do_leader append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto.
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli.
+      break_exists_name plt.
+      break_exists_name ci.
+      break_exists_name n.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
+      subst.
+      exists pli,plt,ci,n. simpl in *; intuition.
+      eapply RIR_doLeader with (net0 := net'); eauto;
+      simpl; repeat find_rewrite; eauto.
+      intros.
+      do_in_app. intuition.
+      find_apply_hyp_hyp.
+      intuition.
+    - exfalso.
+      do_in_map. subst. simpl in *.
+      unfold doLeader in *.
+      repeat break_match; find_inversion; intuition; do_in_map; subst; simpl in *; congruence.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_do_generic_server :
+    raft_net_invariant_do_generic_server append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto.
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli.
+      break_exists_name plt.
+      break_exists_name ci.
+      break_exists_name n.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
+      subst.
+      exists pli,plt,ci,n. simpl in *; intuition.
+      eapply RIR_doGenericServer with (net0 := net'); eauto;
+      simpl; repeat find_rewrite; eauto.
+      intros.
+      do_in_app. intuition.
+      find_apply_hyp_hyp.
+      intuition.
+    - exfalso.
+      do_in_map. subst. simpl in *.
+      unfold doGenericServer in *.
+      repeat break_match; find_inversion; intuition; do_in_map; subst; simpl in *; congruence.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_reboot :
+    raft_net_invariant_reboot append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_reverse_rewrite.
+    find_apply_hyp_hyp.
+    unfold exists_equivalent_network_with_aer in *.
+    break_exists_name net''.
+    break_exists_name pli.
+    break_exists_name plt.
+    break_exists_name ci.
+    break_exists_name n.
+    intuition. subst.
+    remember mkNetwork as mkN.
+    remember mkPacket as mkP.
+    unfold Net.name in *. simpl in *.
+    exists (mkN ((nwPackets net) ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) (nwState net')).
+    subst.
+    exists pli,plt,ci,n. simpl in *; repeat find_rewrite; intuition.
+    eapply RIR_step_f with (net0 := net''); [|eapply SF_reboot with (h0 := h) (failed := [h])]; eauto;
+    simpl; repeat find_rewrite; eauto.
+    f_equal.
+    apply functional_extensionality.
+    intros. repeat find_higher_order_rewrite.
+    unfold update. repeat break_if; subst; eauto; congruence.
+  Qed.
+
+  
+  
+  Lemma subset_reachable :
+    forall net net',
+      nwState net' = nwState net ->
+      (forall p, In p (nwPackets net') -> In p (nwPackets net)) ->
+      raft_intermediate_reachable net ->
+      raft_intermediate_reachable net'.
+  Proof.
+    intros. eauto using RIR_subset.
+  Qed.
+  
+  Lemma append_entries_request_reply_correspondence_state_same_packet_subset :
+    raft_net_invariant_state_same_packet_subset append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp.
+    find_apply_hyp_hyp.
+    unfold exists_equivalent_network_with_aer in *.
+    break_exists_name net''.
+    break_exists_name pli.
+    break_exists_name plt.
+    break_exists_name ci.
+    break_exists_name n.
+    intuition.
+    (exists (mkNetwork (nwPackets net' ++ [{|
+      pSrc := pDst p;
+      pDst := pSrc p;
+      pBody := AppendEntries t n pli plt es ci |}]) (nwState net'))).
+    repeat eexists; intuition; eauto.
+    repeat find_rewrite.
+    break_exists_exists; intuition; repeat find_rewrite; eauto.
+    eapply subset_reachable with (net := net''); eauto.
+    - simpl in *. repeat find_rewrite.
+      apply functional_extensionality. eauto.
+    - simpl.
+      intros. repeat find_rewrite. do_in_app. intuition.
+  Qed.
+  
+  Lemma handleAppendEntries_reply_spec:
+    forall h st (d : raft_data) 
+      (t : term) (n : name) (pli : logIndex) (plt : term) 
+      (es : list entry) (ci : logIndex) (t0 : term) 
+      (es0 : list entry) t' es',
+      handleAppendEntries h st t n pli plt es ci =
+      (d, AppendEntriesReply t' es' true) ->
+      t' = t /\ es' = es.
+  Proof.
+    intros.
+    unfold handleAppendEntries in *.
+    repeat break_match; find_inversion; auto; congruence.
+  Qed.
+  
+  Lemma append_entries_request_reply_correspondence_append_entries :
+    raft_net_invariant_append_entries append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto; [|repeat find_rewrite; in_crush].
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli'.
+      break_exists_name plt'.
+      break_exists_name ci'.
+      break_exists_name n'.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p0) (pSrc p0) (AppendEntries t0 n' pli' plt' es0 ci')]) st').
+      subst.
+      exists pli',plt',ci',n'. simpl in *; intuition.
+      repeat find_rewrite.
+      match goal with
+        | H : nwPackets net' = (?xs ++ ?p :: ?ys) ++ ?l |- _ =>
+          assert (nwPackets net' = xs ++ p :: (ys ++ l))
+            by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
+            clear H
+      end.
+      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      simpl; repeat find_rewrite; eauto;
+      simpl; repeat break_let; eauto; try find_inversion; eauto.
+      intros. do_in_app. simpl in *.
+      intuition; try find_apply_hyp_hyp; intuition; in_crush.
+    - subst. simpl in *. subst. unfold exists_equivalent_network_with_aer.
+      find_eapply_lem_hyp RIR_step_f; [|eapply SF_dup with (failed := [])]; eauto.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      match goal with
+        | _ : raft_intermediate_reachable (mkN (?p :: _) _ ) |- _ =>
+          (exists (mkN (ps' ++ [p]) st'))
+      end.
+      subst.
+      (exists pli, plt, ci, n).
+      simpl in *. intuition.
+      + match goal with
+          | _ : raft_intermediate_reachable (mkNetwork ?ps ?st) |- _ =>
+            eapply RIR_handleMessage with (net0 := (mkNetwork ps st)) (p0 := p)
+                                                                      (xs0 := (p :: xs))
+        end; eauto;
+        simpl in *; repeat find_rewrite; simpl in *; repeat break_let; eauto;
+        repeat find_inversion; eauto.
+        intros.
+        do_in_app. simpl in *. intuition.
+        find_apply_hyp_hyp. intuition; subst; auto.
+      + f_equal. f_equal.
+        destruct p; simpl in *; f_equal; intuition.
+        subst.
+        find_apply_lem_hyp handleAppendEntries_reply_spec; auto.
+        intuition. subst. auto.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_append_entries_reply :
+    raft_net_invariant_append_entries_reply append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto; [|repeat find_rewrite; in_crush].
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli'.
+      break_exists_name plt'.
+      break_exists_name ci'.
+      break_exists_name n'.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p0) (pSrc p0) (AppendEntries t0 n' pli' plt' es0 ci')]) st').
+      subst.
+      exists pli',plt',ci',n'. simpl in *; intuition.
+      repeat find_rewrite.
+      match goal with
+        | H : nwPackets net' = (?xs ++ ?p :: ?ys) ++ ?l |- _ =>
+          assert (nwPackets net' = xs ++ p :: (ys ++ l))
+            by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
+            clear H
+      end.
+      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      simpl; repeat find_rewrite; eauto;
+      simpl; repeat break_let; eauto; try find_inversion; eauto.
+      intros. do_in_app. simpl in *.
+      intuition; try find_apply_hyp_hyp; intuition; in_crush.
+    - do_in_map.
+      subst. simpl in *.
+      find_apply_lem_hyp handleAppendEntriesReply_packets.
+      subst. simpl in *. intuition.
+  Qed.
+
+
+  Lemma append_entries_request_reply_correspondence_request_vote :
+    raft_net_invariant_request_vote append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    - copy_eapply_prop_hyp pBody pBody; auto; [|repeat find_rewrite; in_crush].
+      unfold exists_equivalent_network_with_aer in *.
+      break_exists_name net'.
+      break_exists_name pli'.
+      break_exists_name plt'.
+      break_exists_name ci'.
+      break_exists_name n'.
+      intuition.
+      remember mkNetwork as mkN.
+      remember mkPacket as mkP.
+      unfold Net.name in *. simpl in *.
+      exists (mkN (ps' ++ [mkP (pDst p0) (pSrc p0) (AppendEntries t0 n' pli' plt' es ci')]) st').
+      subst.
+      exists pli',plt',ci',n'. simpl in *; intuition.
+      repeat find_rewrite.
+      match goal with
+        | H : nwPackets net' = (?xs ++ ?p :: ?ys) ++ ?l |- _ =>
+          assert (nwPackets net' = xs ++ p :: (ys ++ l))
+            by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
+            clear H
+      end.
+      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      simpl; repeat find_rewrite; eauto;
+      simpl; repeat break_let; eauto; try find_inversion; eauto.
+      intros. do_in_app. simpl in *.
+      intuition; try find_apply_hyp_hyp; intuition; in_crush.
+    - subst. simpl in *. subst.
+      unfold handleRequestVote in *.
+      repeat break_match; find_inversion; congruence.
+  Qed.
+
+  Lemma append_entries_request_reply_correspondence_request_vote_reply :
+    raft_net_invariant_request_vote_reply append_entries_request_reply_correspondence.
+  Proof.
+    red. unfold append_entries_request_reply_correspondence. intros.
+    simpl in *.
+    find_apply_hyp_hyp. intuition.
+    copy_eapply_prop_hyp pBody pBody; auto; [|repeat find_rewrite; in_crush].
+    unfold exists_equivalent_network_with_aer in *.
+    break_exists_name net'.
+    break_exists_name pli'.
+    break_exists_name plt'.
+    break_exists_name ci'.
+    break_exists_name n'.
+    intuition.
+    remember mkNetwork as mkN.
+    remember mkPacket as mkP.
+    unfold Net.name in *. simpl in *.
+    exists (mkN (ps' ++ [mkP (pDst p0) (pSrc p0) (AppendEntries t0 n' pli' plt' es ci')]) st').
+    subst.
+    exists pli',plt',ci',n'. simpl in *; intuition.
+    repeat find_rewrite.
+    match goal with
+      | H : nwPackets net' = (?xs ++ ?p :: ?ys) ++ ?l |- _ =>
+        assert (nwPackets net' = xs ++ p :: (ys ++ l))
+          by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
+          clear H
+    end.
+    eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      simpl; repeat find_rewrite; eauto;
+      simpl; repeat break_let; eauto; try find_inversion; eauto.
+    intros. do_in_app. simpl in *.
+    intuition; try find_apply_hyp_hyp; intuition; in_crush.
+  Qed.
+
+  Instance aerrci : append_entries_request_reply_correspondence_interface.
+  split.
+  intros. apply raft_net_invariant; auto.
+  - exact append_entries_request_reply_correspondence_init.
+  - exact append_entries_request_reply_correspondence_client_request.
+  - exact append_entries_request_reply_correspondence_timeout.
+  - exact append_entries_request_reply_correspondence_append_entries.
+  - exact append_entries_request_reply_correspondence_append_entries_reply.
+  - exact append_entries_request_reply_correspondence_request_vote.
+  - exact append_entries_request_reply_correspondence_request_vote_reply.
+  - exact append_entries_request_reply_correspondence_do_leader.
+  - exact append_entries_request_reply_correspondence_do_generic_server.
+  - exact append_entries_request_reply_correspondence_state_same_packet_subset.
+  - exact append_entries_request_reply_correspondence_reboot.
+  Qed.
+  
+
+End AppendEntriesRequestReplyCorrespondence.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -241,6 +241,9 @@ Require Import AppendEntriesReplySublogProof.
 Require Import LeaderLogsLogPropertiesInterface.
 Require Import LeaderLogsLogPropertiesProof.
 
+Require Import AppendEntriesRequestReplyCorrespondenceInterface.
+Require Import AppendEntriesRequestReplyCorrespondenceProof.
+
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.
 Hint Extern 4 (@FailureParams _ _) => apply failure_params : typeclass_instances.
@@ -318,6 +321,7 @@ Hint Extern 4 (@no_append_entries_replies_to_self_interface _ _ _) => apply noae
 Hint Extern 4 (@log_all_entries_interface _ _ _) => apply laei : typeclass_instances.
 Hint Extern 4 (@append_entries_reply_sublog_interface _ _ _) => apply aersi : typeclass_instances.
 Hint Extern 4 (@log_properties_hold_on_leader_logs_interface _ _ _) => apply lpholli : typeclass_instances.
+Hint Extern 4 (@append_entries_request_reply_correspondence_interface _ _ _) => apply aerrci : typeclass_instances.
 
 Section EndToEndProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/MatchIndexAllEntriesProof.v
+++ b/raft-proofs/MatchIndexAllEntriesProof.v
@@ -128,10 +128,10 @@ Section MatchIndexAllEntries.
   Qed.
 
   Lemma lifted_append_entries_reply_sublog :
-    forall net p t es res h e,
+    forall net p t es h e,
       refined_raft_intermediate_reachable net ->
       In p (nwPackets net) ->
-      pBody p = AppendEntriesReply t es res ->
+      pBody p = AppendEntriesReply t es true ->
       currentTerm (snd (nwState net h)) = t ->
       type (snd (nwState net h)) = Leader ->
       In e es ->

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -196,6 +196,8 @@ Section RaftRefinementProof.
        + eapply_prop refined_raft_net_invariant_reboot; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          destruct (nwState net h); auto.
+    - eapply_prop refined_raft_net_invariant_state_same_packet_subset; [ | | | eauto ]; eauto.
+      repeat find_rewrite. eauto.
     - eapply refined_raft_invariant_handle_input; eauto.
     - eapply refined_raft_invariant_handle_message; eauto.
     - eapply_prop refined_raft_net_invariant_do_leader; eauto.
@@ -407,6 +409,8 @@ Section RaftRefinementProof.
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          * econstructor. eauto. eapply SF_reboot; eauto.
          * destruct (nwState net h); auto.
+    - eapply_prop refined_raft_net_invariant_state_same_packet_subset; [ | | | eauto]; eauto.
+      repeat find_rewrite. eauto.
     - eapply refined_raft_invariant_handle_input'; eauto.
       eapply RRIR_handleInput; eauto.
     - eapply refined_raft_invariant_handle_message'; eauto.
@@ -448,6 +452,15 @@ Section RaftRefinementProof.
       specialize (H1 failed (deghost net) failed' (deghost net') out).
       apply H1; auto.
       apply ghost_simulation_1; auto.
+    - pose proof (RIR_subset).
+      specialize (H2 (deghost net) (deghost net')).
+      concludes.
+      simpl in *.
+      repeat break_match; simpl in *. subst.
+      concludes.
+      forwards; [intros; apply in_map_iff; do_in_map;
+                 eexists; eauto|].
+      auto.
     - unfold deghost in *. simpl in *.
       eapply RIR_handleInput; eauto.
       + simpl in *. repeat break_match. simpl in *.
@@ -532,6 +545,23 @@ Section RaftRefinementProof.
       subst.
       exists x0. intuition.
       eapply RRIR_step_f; eauto.
+    - break_exists.
+      intuition. subst. simpl in *.
+      exists {| nwPackets := map ghost_packet (Net.nwPackets net') ;
+           nwState := nwState x
+        |}.
+      intuition; simpl in *; eauto.
+      + repeat break_match. subst. simpl in *.
+        destruct net'. simpl in *.
+        unfold deghost. simpl.
+        rewrite map_map. simpl.
+        repeat find_rewrite.
+        erewrite map_ext; [erewrite map_id|]; auto.
+        intros. simpl. destruct a; auto.
+      + eapply RRIR_subset; [eauto | |]; simpl; auto.
+        intros. do_in_map.
+        subst. find_apply_hyp_hyp. do_in_map.
+        subst. simpl. destruct x1. simpl. auto.
     - break_exists. break_and.
       subst.
       exists {| nwPackets := map ghost_packet ps' ;

--- a/raft/AppendEntriesReplySublogInterface.v
+++ b/raft/AppendEntriesReplySublogInterface.v
@@ -11,9 +11,9 @@ Section AppendEntriesReplySublog.
   Context {raft_params : RaftParams orig_base_params}.
 
   Definition append_entries_reply_sublog net :=
-    forall p t es res h e,
+    forall p t es h e,
       In p (nwPackets net) ->
-      pBody p = AppendEntriesReply t es res ->
+      pBody p = AppendEntriesReply t es true ->
       currentTerm (nwState net h) = t ->
       type (nwState net h) = Leader ->
       In e es ->

--- a/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
+++ b/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
@@ -1,0 +1,43 @@
+Require Import List.
+Import ListNotations.
+Require Import Omega.
+Require Import FunctionalExtensionality.
+
+
+Require Import VerdiTactics.
+Require Import Net.
+Require Import Util.
+Require Import Raft.
+
+Require Import CommonTheorems.
+Require Import SpecLemmas.
+
+
+Section AppendEntriesRequestReplyCorrespondence.
+  Context {orig_base_params : BaseParams}.
+  Context {one_node_params : OneNodeParams orig_base_params}.
+  Context {raft_params : RaftParams orig_base_params}.
+
+  Definition exists_equivalent_network_with_aer net from to t es :=
+    exists net' pli plt ci n,
+      raft_intermediate_reachable net' /\
+      nwState net' = nwState net /\
+      nwPackets net' = nwPackets net ++
+                                 [ {| pSrc := from; pDst := to; pBody := AppendEntries t n pli plt es ci |} ].
+
+  Definition append_entries_request_reply_correspondence net :=
+    forall p t es,
+      In p (nwPackets net) ->
+      pBody p = AppendEntriesReply t es true ->
+      exists_equivalent_network_with_aer net (pDst p) (pSrc p) t es.
+
+  Class append_entries_request_reply_correspondence_interface : Prop :=
+    {
+      append_entries_request_reply_correspondence_invariant :
+        forall net,
+          raft_intermediate_reachable net ->
+          append_entries_request_reply_correspondence net
+    }.
+
+    
+End AppendEntriesRequestReplyCorrespondence.

--- a/raft/DecompositionWithPostState.v
+++ b/raft/DecompositionWithPostState.v
@@ -334,6 +334,8 @@ Section DecompositionWithPostState.
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          eapply RIR_step_f; eauto.
          now econstructor; eauto.
+    - eapply_prop raft_net_invariant_state_same_packet_subset; [ | | |eauto]; eauto.
+      repeat find_rewrite. eauto.
     - eapply raft_invariant_handle_input'; eauto using RIR_handleInput.
     - eapply raft_invariant_handle_message'; eauto using RIR_handleMessage.
     - eapply_prop raft_net_invariant_do_leader'; eauto using RIR_doLeader.

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -529,6 +529,12 @@ Section Raft.
         raft_intermediate_reachable net ->
         step_f (failed, net) (failed', net') out ->
         raft_intermediate_reachable net'
+  | RIR_subset :
+      forall net net',
+        raft_intermediate_reachable net ->
+        nwState net' = nwState net ->
+        (forall p, In p (nwPackets net') -> In p (nwPackets net)) ->
+        raft_intermediate_reachable net'
   | RIR_handleInput :
       forall net h inp out d l ps' st',
         raft_intermediate_reachable net ->
@@ -836,6 +842,8 @@ Section Raft.
        + auto.
        + eapply_prop raft_net_invariant_reboot; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
+    - eapply_prop raft_net_invariant_state_same_packet_subset; [ | | | eauto]; eauto.
+      repeat find_rewrite; auto.
     - eapply raft_invariant_handle_input; eauto.
     - eapply raft_invariant_handle_message; eauto.
     - eapply_prop raft_net_invariant_do_leader; eauto.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -181,6 +181,12 @@ Section RaftRefinementInterface.
         refined_raft_intermediate_reachable net ->
         step_f (failed, net) (failed', net') out ->
         refined_raft_intermediate_reachable net'
+  | RRIR_subset :
+      forall net net',
+        refined_raft_intermediate_reachable net ->
+        nwState net' = nwState net ->
+        (forall p, In p (nwPackets net') -> In p (nwPackets net)) ->
+        refined_raft_intermediate_reachable net'
   | RRIR_handleInput :
       forall net h inp gd out d l ps' st',
         refined_raft_intermediate_reachable net ->


### PR DESCRIPTION
There's a decent amount of stuff here, but each commit is relatively self-contained. The only controversial thing (besides rampant usage of functional extensionality) is the change to the reachability relation(s). The idea is to explicitly put a subset step in there so that I can later show that, when we take a subset step in the decomposition, there's a corresponding sequence (of length 1) of reachability steps. This should be possible without this change, but it's a pain.

For an example of how the correspondence thing is used, check out AppendEntriesReplySublog.