### PR TITLE
Aer correspondence

### DIFF
--- a/core/DupDropReordering.v
+++ b/core/DupDropReordering.v
@@ -1,0 +1,242 @@
+Require Import List.
+Import ListNotations.
+
+Require Import Relations.
+Import Relation_Operators.
+
+Require Import Permutation.
+
+Require Import VerdiTactics.
+Require Import Net.
+
+Section dup_drop_reorder.
+  Variable A : Type.
+  Hypothesis A_eq_dec : forall x y : A, {x = y} + {x <> y}.
+
+  Inductive dup_drop_step : list A -> list A -> Prop :=
+  | DDS_dup : forall l p,
+      In p l ->
+      dup_drop_step l (p :: l)
+  | DDS_drop : forall xs p ys,
+      dup_drop_step (xs ++ p :: ys) (xs ++ ys).
+
+  Definition dup_drop_step_star := clos_refl_trans_n1 _ dup_drop_step.
+
+  Lemma dup_drop_step_star_trans :
+    forall l l' l'',
+      dup_drop_step_star l l' ->
+      dup_drop_step_star l' l'' ->
+      dup_drop_step_star l l''.
+  Proof.
+    intros.
+    apply clos_rt_rtn1_iff.
+    eapply rt_trans; apply clos_rt_rtn1_iff; eauto.
+  Qed.
+
+  Lemma dup_drop_step_star_step_n1 :
+    forall l l' l'',
+      dup_drop_step_star l l' ->
+      dup_drop_step l' l'' ->
+      dup_drop_step_star l l''.
+  Proof.
+    intros.
+    econstructor; eauto.
+  Qed.
+
+  Lemma dup_drop_step_star_step_1n :
+    forall l l' l'',
+      dup_drop_step l l' ->
+      dup_drop_step_star l' l'' ->
+      dup_drop_step_star l l''.
+  Proof.
+    intros.
+    apply clos_rt_rtn1_iff.
+    apply clos_rt_rt1n_iff.
+    econstructor; [eauto|].
+    apply clos_rt_rt1n_iff.
+    apply clos_rt_rtn1_iff.
+    auto.
+  Qed.
+
+  Lemma dup_drop_step_star_step_1 :
+    forall l l',
+      dup_drop_step l l' ->
+      dup_drop_step_star l l'.
+  Proof.
+    intros.
+    eapply dup_drop_step_star_step_1n; eauto.
+    constructor.
+  Qed.
+
+  Lemma dup_drop_swap :
+    forall l x y,
+      dup_drop_step_star (x :: y :: l) (y :: x :: l).
+  Proof.
+    intros.
+    eapply dup_drop_step_star_step_1n; [eapply DDS_dup with (p := y); simpl; auto|].
+    eapply dup_drop_step_star_step_1n.
+    eapply DDS_drop with (xs := [y; x]) (p := y) (ys := l).
+    constructor.
+  Qed.
+
+  Lemma dup_drop_cons :
+    forall l l' x,
+      dup_drop_step_star l l' ->
+      dup_drop_step_star (x :: l) (x :: l').
+  Proof.
+    induction 1.
+    - constructor.
+    - invc H.
+      + eapply dup_drop_step_star_trans; [eauto|].
+        eapply dup_drop_step_star_step_1n; [eapply DDS_dup with (p := p); simpl; auto|].
+        auto using dup_drop_swap.
+      + eapply dup_drop_step_star_trans; [eauto|].
+        eapply dup_drop_step_star_step_1n.
+        eapply DDS_drop with (xs := x :: xs) (p := p) (ys := ys).
+        constructor.
+  Qed.
+
+  Lemma dup_drop_Permutation :
+    forall l l',
+      Permutation l l' ->
+      dup_drop_step_star l l'.
+  Proof.
+    induction 1.
+    - constructor.
+    - auto using dup_drop_cons.
+    - auto using dup_drop_swap.
+    - eauto using dup_drop_step_star_trans.
+  Qed.
+
+  Lemma remove_not_in_nop :
+    forall a l,
+      ~ In a l ->
+      remove A_eq_dec a l = l.
+  Proof.
+    induction l; simpl; intuition.
+    break_if; congruence.
+  Qed.
+
+  Lemma dup_drop_in :
+    forall l l' a,
+      dup_drop_step_star l l' ->
+      In a l' ->
+      In a l.
+  Proof.
+    induction 1; intros.
+    - auto.
+    - invc H.
+      + simpl in *. intuition.
+        subst. auto.
+      + apply IHclos_refl_trans_n1.
+        find_apply_lem_hyp in_app_or.
+        intuition.
+  Qed.
+
+  Lemma dup_drop_dup_early :
+    forall l l' a,
+      dup_drop_step_star l l' ->
+      In a l ->
+      dup_drop_step_star l (a :: l').
+  Proof.
+    induction 1; intros.
+    - apply dup_drop_step_star_step_1. constructor. auto.
+    - concludes.
+      eapply dup_drop_step_star_trans; eauto.
+      apply dup_drop_cons.
+      apply dup_drop_step_star_step_1.
+      auto.
+  Qed.
+
+  Lemma dup_drop_step_star_remove_In :
+    forall l' l a,
+      In a l' ->
+      dup_drop_step_star l (remove A_eq_dec a l') ->
+      dup_drop_step_star (a :: l) l'.
+  Proof.
+    induction l'; simpl; intuition.
+    - subst. break_if; try congruence.
+      destruct (in_dec A_eq_dec a0 l').
+      + find_apply_hyp_hyp.
+        eapply dup_drop_step_star_trans; eauto.
+        eapply dup_drop_step_star_step_1.
+        apply DDS_dup; auto.
+      + rewrite remove_not_in_nop in * by auto.
+        apply dup_drop_cons. auto.
+    - break_if.
+      + subst.
+        find_apply_hyp_hyp.
+        eapply dup_drop_step_star_trans; eauto.
+        eapply dup_drop_step_star_step_1.
+        apply DDS_dup; auto.
+      + pose proof dup_drop_in l _ a $(eauto)$.
+        concludes.
+        eapply dup_drop_step_star_step_n1 in H0; [| eapply DDS_drop with (xs := [])].
+        simpl in *.
+        apply IHl' in H0; auto.
+        apply dup_drop_dup_early; auto.
+        simpl. intuition.
+  Qed.
+
+  Lemma remove_In_elim :
+    forall x a l,
+      In x (remove A_eq_dec a l) ->
+      x <> a /\ In x l.
+  Proof.
+    induction l; simpl; intuition; break_if; subst; simpl in *; intuition.
+  Qed.
+
+  Lemma dup_drop_reorder :
+    forall l l' : list A,
+      (forall x, In x l' -> In x l) ->
+      dup_drop_step_star l l'.
+  Proof.
+    induction l; intros.
+    - destruct l'.
+      + constructor.
+      + simpl in *. exfalso. eauto.
+    - destruct (in_dec A_eq_dec a l').
+      + eapply dup_drop_step_star_remove_In. auto.
+        apply IHl.
+        intros.
+        find_apply_lem_hyp remove_In_elim.
+        intuition.
+        find_apply_hyp_hyp.
+        simpl in *. intuition.
+        exfalso. eauto.
+      + eapply dup_drop_step_star_step_1n.
+        eapply DDS_drop with (xs := []).
+        apply IHl.
+        simpl in *. intros.
+        find_copy_apply_hyp_hyp.
+        intuition.
+        subst. exfalso. eauto.
+  Qed.
+End dup_drop_reorder.
+
+Section step_f_dup_drop_step.
+  Context `{params : FailureParams}.
+
+  Theorem step_f_dup_drop_step :
+    forall ps ps' Sigma f,
+      dup_drop_step_star _ ps ps' ->
+      step_f_star (f, mkNetwork ps Sigma) (f, mkNetwork ps' Sigma) [].
+  Proof.
+    induction 1.
+    - constructor.
+    - match goal with
+      | [ H : dup_drop_step _ _ _ |- _ ] => invc H
+      end.
+      + find_apply_lem_hyp in_split. break_exists. break_and. subst.
+        apply refl_trans_n1_1n_trace.
+        eapply RTn1TStep with (cs := []).
+        * apply refl_trans_1n_n1_trace.
+          apply IHclos_refl_trans_n1.
+        * eapply SF_dup; [simpl; eauto|]. auto.
+      + apply refl_trans_n1_1n_trace.
+        eapply RTn1TStep with (cs := []).
+        * apply refl_trans_1n_n1_trace.
+          apply IHclos_refl_trans_n1.
+        * eapply SF_drop; [simpl; eauto|]. auto.
+  Qed.
+End step_f_dup_drop_step.

--- a/core/Net.v
+++ b/core/Net.v
@@ -250,6 +250,10 @@ Section StepAsync.
 
   Definition send_packets src ps := (map (fun m => mkPacket src (fst m) (snd m)) ps).
 
+  Definition packet_eq_dec (p q : packet) : {p = q} + {p <> q}.
+    decide equality; auto using name_eq_dec, msg_eq_dec.
+  Defined.
+
   Record network := mkNetwork { nwPackets : list packet;
                                 nwState   : name -> data }.
 

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -17,6 +17,8 @@ Require Import DecompositionWithPostState.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 Require Import AppendEntriesRequestReplyCorrespondenceInterface.
 
+Require Import DupDropReordering.
+
 Section AppendEntriesRequestReplyCorrespondence.
   Context {orig_base_params : BaseParams}.
   Context {one_node_params : OneNodeParams orig_base_params}.
@@ -195,7 +197,15 @@ Section AppendEntriesRequestReplyCorrespondence.
       raft_intermediate_reachable net ->
       raft_intermediate_reachable net'.
   Proof.
-    intros. eauto using RIR_subset.
+    intros.
+    pose proof dup_drop_reorder _ packet_eq_dec _ _ $(eauto)$.
+    match goal with
+    | [ H : dup_drop_step_star _ _ _ |- _ ] =>
+      eapply step_f_dup_drop_step with (f := []) (Sigma := nwState net) in H
+    end.
+    eapply step_f_star_raft_intermediate_reachable_extend with (f := []) (f' := []) (tr := []); [|eauto].
+    destruct net, net'. simpl in *. subst.
+    auto.
   Qed.
   
   Lemma append_entries_request_reply_correspondence_state_same_packet_subset :

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -196,8 +196,6 @@ Section RaftRefinementProof.
        + eapply_prop refined_raft_net_invariant_reboot; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          destruct (nwState net h); auto.
-    - eapply_prop refined_raft_net_invariant_state_same_packet_subset; [ | | | eauto ]; eauto.
-      repeat find_rewrite. eauto.
     - eapply refined_raft_invariant_handle_input; eauto.
     - eapply refined_raft_invariant_handle_message; eauto.
     - eapply_prop refined_raft_net_invariant_do_leader; eauto.
@@ -409,8 +407,6 @@ Section RaftRefinementProof.
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          * econstructor. eauto. eapply SF_reboot; eauto.
          * destruct (nwState net h); auto.
-    - eapply_prop refined_raft_net_invariant_state_same_packet_subset; [ | | | eauto]; eauto.
-      repeat find_rewrite. eauto.
     - eapply refined_raft_invariant_handle_input'; eauto.
       eapply RRIR_handleInput; eauto.
     - eapply refined_raft_invariant_handle_message'; eauto.
@@ -452,15 +448,6 @@ Section RaftRefinementProof.
       specialize (H1 failed (deghost net) failed' (deghost net') out).
       apply H1; auto.
       apply ghost_simulation_1; auto.
-    - pose proof (RIR_subset).
-      specialize (H2 (deghost net) (deghost net')).
-      concludes.
-      simpl in *.
-      repeat break_match; simpl in *. subst.
-      concludes.
-      forwards; [intros; apply in_map_iff; do_in_map;
-                 eexists; eauto|].
-      auto.
     - unfold deghost in *. simpl in *.
       eapply RIR_handleInput; eauto.
       + simpl in *. repeat break_match. simpl in *.
@@ -545,23 +532,6 @@ Section RaftRefinementProof.
       subst.
       exists x0. intuition.
       eapply RRIR_step_f; eauto.
-    - break_exists.
-      intuition. subst. simpl in *.
-      exists {| nwPackets := map ghost_packet (Net.nwPackets net') ;
-           nwState := nwState x
-        |}.
-      intuition; simpl in *; eauto.
-      + repeat break_match. subst. simpl in *.
-        destruct net'. simpl in *.
-        unfold deghost. simpl.
-        rewrite map_map. simpl.
-        repeat find_rewrite.
-        erewrite map_ext; [erewrite map_id|]; auto.
-        intros. simpl. destruct a; auto.
-      + eapply RRIR_subset; [eauto | |]; simpl; auto.
-        intros. do_in_map.
-        subst. find_apply_hyp_hyp. do_in_map.
-        subst. simpl. destruct x1. simpl. auto.
     - break_exists. break_and.
       subst.
       exists {| nwPackets := map ghost_packet ps' ;

--- a/raft/DecompositionWithPostState.v
+++ b/raft/DecompositionWithPostState.v
@@ -334,8 +334,6 @@ Section DecompositionWithPostState.
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
          eapply RIR_step_f; eauto.
          now econstructor; eauto.
-    - eapply_prop raft_net_invariant_state_same_packet_subset; [ | | |eauto]; eauto.
-      repeat find_rewrite. eauto.
     - eapply raft_invariant_handle_input'; eauto using RIR_handleInput.
     - eapply raft_invariant_handle_message'; eauto using RIR_handleMessage.
     - eapply_prop raft_net_invariant_do_leader'; eauto using RIR_doLeader.

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -586,6 +586,21 @@ Section Raft.
     eapply step_f_star_raft_intermediate_reachable'; eauto.
   Qed.
 
+  Lemma step_f_star_raft_intermediate_reachable_extend :
+    forall f net f' net' tr,
+      step_f_star (f, net) (f', net') tr ->
+      raft_intermediate_reachable net ->
+      raft_intermediate_reachable net'.
+  Proof.
+    intros.
+    prep_induction H.
+    induction H using refl_trans_1n_trace_n1_ind; intros; subst.
+    - find_inversion. auto.
+    - destruct x'. simpl in *.
+      eapply RIR_step_f; [|eauto].
+      eauto.
+  Qed.
+
   Definition raft_net_invariant_client_request (P : network -> Prop) :=
     forall h net st' ps' out d l client id c,
       handleClientRequest h (nwState net h) client id c = (out, d, l) ->

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -529,12 +529,6 @@ Section Raft.
         raft_intermediate_reachable net ->
         step_f (failed, net) (failed', net') out ->
         raft_intermediate_reachable net'
-  | RIR_subset :
-      forall net net',
-        raft_intermediate_reachable net ->
-        nwState net' = nwState net ->
-        (forall p, In p (nwPackets net') -> In p (nwPackets net)) ->
-        raft_intermediate_reachable net'
   | RIR_handleInput :
       forall net h inp out d l ps' st',
         raft_intermediate_reachable net ->
@@ -842,8 +836,6 @@ Section Raft.
        + auto.
        + eapply_prop raft_net_invariant_reboot; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
-    - eapply_prop raft_net_invariant_state_same_packet_subset; [ | | | eauto]; eauto.
-      repeat find_rewrite; auto.
     - eapply raft_invariant_handle_input; eauto.
     - eapply raft_invariant_handle_message; eauto.
     - eapply_prop raft_net_invariant_do_leader; eauto.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -181,12 +181,6 @@ Section RaftRefinementInterface.
         refined_raft_intermediate_reachable net ->
         step_f (failed, net) (failed', net') out ->
         refined_raft_intermediate_reachable net'
-  | RRIR_subset :
-      forall net net',
-        refined_raft_intermediate_reachable net ->
-        nwState net' = nwState net ->
-        (forall p, In p (nwPackets net') -> In p (nwPackets net)) ->
-        refined_raft_intermediate_reachable net'
   | RRIR_handleInput :
       forall net h inp gd out d l ps' st',
         refined_raft_intermediate_reachable net ->


### PR DESCRIPTION
Instead of adding a subset constructor to the reachability relations, we prove that any subset is achievable through repeated applications of duping and dropping. This is proved generically in core/DupDropReordering.v and instantiated to prove subset_reachable in raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v