### PR TITLE
Cleanup imports

### DIFF
--- a/core/DupDropReordering.v
+++ b/core/DupDropReordering.v
@@ -2,7 +2,6 @@ Require Import List.
 Import ListNotations.
 
 Require Import Relations.
-Import Relation_Operators.
 
 Require Import Permutation.
 

--- a/core/GhostSimulations.v
+++ b/core/GhostSimulations.v
@@ -1,17 +1,8 @@
 Require Import List.
-Import ListNotations.
-
-Require Import Arith.
-Require Import ZArith.
-Require Import Omega.
 
 Require Import StructTact.StructTactics.
-Require Import HandlerMonad.
 Require Import Net.
 Require Import StructTact.Util.
-
-Require Import UpdateLemmas.
-Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import FunctionalExtensionality.
 Require Import Simulations.

--- a/core/InverseTraceRelations.v
+++ b/core/InverseTraceRelations.v
@@ -1,8 +1,6 @@
 Require Import List.
-Import ListNotations.
 
 Require Import Net.
-Require Import StructTact.Util.
 Require Import StructTact.StructTactics.
 
 Class InverseTraceRelation `{State : Type} `{Event : Type} (step : step_relation State Event) :=

--- a/core/Net.v
+++ b/core/Net.v
@@ -1,14 +1,6 @@
 Require Import List.
-Require Import Arith.
-Require Import Omega.
 Import ListNotations.
-Require Import Sorting.Permutation.
-Require Import FunctionalExtensionality.
-Require Import Relations.Relation_Operators.
-Require Import Relations.Operators_Properties.
-Require Import StructTact.Util.
 Require Import StructTact.StructTactics.
-
 Require Export VerdiHints.
 
 Set Implicit Arguments.

--- a/core/Simulations.v
+++ b/core/Simulations.v
@@ -1,16 +1,10 @@
 Require Import List.
 Import ListNotations.
 
-Require Import Arith.
-Require Import ZArith.
-Require Import Omega.
-
 Require Import StructTact.StructTactics.
-Require Import HandlerMonad.
 Require Import Net.
 Require Import StructTact.Util.
 
-Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import FunctionalExtensionality.

--- a/core/StateMachineHandlerMonad.v
+++ b/core/StateMachineHandlerMonad.v
@@ -1,5 +1,4 @@
 Require Import List.
-Import ListNotations.
 
 (*
 This file is very similar to HandlerMonad.v, but supports step_1

--- a/core/StatePacketPacketDecomposition.v
+++ b/core/StatePacketPacketDecomposition.v
@@ -1,9 +1,5 @@
-Require Export StructTact.Util.
-Require Export Net.
-Require Export List.
-Export ListNotations.
+Require Import Verdi.
 
-Require Import StructTact.StructTactics.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/core/TraceRelations.v
+++ b/core/TraceRelations.v
@@ -2,7 +2,6 @@ Require Import List.
 Import ListNotations.
 
 Require Import Net.
-Require Import StructTact.Util.
 Require Import StructTact.StructTactics.
 
 Class TraceRelation `{State : Type} `{Event : Type} (step : step_relation State Event) :=

--- a/core/Verdi.v
+++ b/core/Verdi.v
@@ -1,0 +1,12 @@
+Require Export List.
+Export ListNotations.
+Require Export Arith.
+Require Export Omega.
+Require Export Coq.Numbers.Natural.Abstract.NDiv.
+Require Export Sorting.Permutation.
+
+Require Export StructTact.Util.
+Require Export StructTact.StructTactics.
+
+Require Export VerdiHints.
+Require Export Net.

--- a/extraction/vard/coq/ExtractVarDRaft.v
+++ b/extraction/vard/coq/ExtractVarDRaft.v
@@ -1,9 +1,6 @@
-Require Import Net.
-Require Import Arith.
+Require Import Verdi.
 Require Import NPeano.
 Require Import PeanoNat.
-Require Import List.
-Require Import StructTact.Util.
 Require Import VarD.
 Require Import VarDRaft.
 

--- a/extraction/vard/coq/VarDRaft.v
+++ b/extraction/vard/coq/VarDRaft.v
@@ -1,4 +1,3 @@
-Require Import Net.
 Require Import Raft.
 Require Import VarD.
 

--- a/raft-proofs/AllEntriesCandidateEntriesProof.v
+++ b/raft-proofs/AllEntriesCandidateEntriesProof.v
@@ -1,7 +1,8 @@
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.
 Require Import CommonTheorems.

--- a/raft-proofs/AllEntriesCandidateEntriesProof.v
+++ b/raft-proofs/AllEntriesCandidateEntriesProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/AllEntriesCandidateEntriesProof.v
+++ b/raft-proofs/AllEntriesCandidateEntriesProof.v
@@ -4,9 +4,7 @@ Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
-Require Import RefinementCommonDefinitions.
 Require Import RefinementCommonTheorems.
 
 Require Import CandidateEntriesInterface.

--- a/raft-proofs/AllEntriesIndicesGt0Proof.v
+++ b/raft-proofs/AllEntriesIndicesGt0Proof.v
@@ -3,7 +3,6 @@ Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.
-Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/AllEntriesIndicesGt0Proof.v
+++ b/raft-proofs/AllEntriesIndicesGt0Proof.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
-Require Import Omega.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/AllEntriesLeaderLogsProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsProof.v
@@ -1,11 +1,9 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
 
 Require Import AppendEntriesRequestLeaderLogsInterface.
 Require Import OneLeaderLogPerTermInterface.

--- a/raft-proofs/AllEntriesLeaderLogsProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/AllEntriesLeaderLogsTermProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsTermProof.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/AllEntriesLeaderLogsTermProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsTermProof.v
@@ -1,7 +1,8 @@
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import RefinementSpecLemmas.
 Require Import SpecLemmas.

--- a/raft-proofs/AllEntriesLeaderSublogProof.v
+++ b/raft-proofs/AllEntriesLeaderSublogProof.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/AllEntriesLeaderSublogProof.v
+++ b/raft-proofs/AllEntriesLeaderSublogProof.v
@@ -2,8 +2,6 @@ Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import CommonDefinitions.
-Require Import RefinementCommonDefinitions.
 Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.

--- a/raft-proofs/AllEntriesLogMatchingProof.v
+++ b/raft-proofs/AllEntriesLogMatchingProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.

--- a/raft-proofs/AllEntriesLogMatchingProof.v
+++ b/raft-proofs/AllEntriesLogMatchingProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -1,8 +1,9 @@
 Require Import GhostSimulations.
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.
 Require Import SpecLemmas.

--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/AllEntriesTermSanityProof.v
+++ b/raft-proofs/AllEntriesTermSanityProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/AllEntriesTermSanityProof.v
+++ b/raft-proofs/AllEntriesTermSanityProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/AllEntriesVotesWithLogProof.v
+++ b/raft-proofs/AllEntriesVotesWithLogProof.v
@@ -5,7 +5,6 @@ Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/AllEntriesVotesWithLogProof.v
+++ b/raft-proofs/AllEntriesVotesWithLogProof.v
@@ -1,8 +1,9 @@
 Require Import GhostSimulations.
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.
 Require Import SpecLemmas.

--- a/raft-proofs/AllEntriesVotesWithLogProof.v
+++ b/raft-proofs/AllEntriesVotesWithLogProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/AppendEntriesLeaderProof.v
+++ b/raft-proofs/AppendEntriesLeaderProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/AppendEntriesLeaderProof.v
+++ b/raft-proofs/AppendEntriesLeaderProof.v
@@ -5,9 +5,7 @@ Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
 
 Require Import AppendEntriesRequestsCameFromLeadersInterface.
 Require Import OneLeaderLogPerTermInterface.

--- a/raft-proofs/AppendEntriesReplySublogProof.v
+++ b/raft-proofs/AppendEntriesReplySublogProof.v
@@ -1,10 +1,5 @@
 Require Import Raft.
 
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
-Require Import SpecLemmas.
-
-Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import AppendEntriesReplySublogInterface.

--- a/raft-proofs/AppendEntriesReplySublogProof.v
+++ b/raft-proofs/AppendEntriesReplySublogProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Require Import CommonTheorems.

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -1,4 +1,3 @@
-Require Import Nat.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -1,10 +1,8 @@
-Require Import PeanoNat.
 Require Import Nat.
 Require Import GhostSimulations.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -1,3 +1,5 @@
+Require Import PeanoNat.
+Require Import Nat.
 Require Import GhostSimulations.
 
 Require Import Raft.
@@ -317,9 +319,6 @@ Section AppendEntriesRequestLeaderLogs.
       subst; simpl in *; do_in_map; subst; simpl in *; congruence.
   Qed.
 
-  Require Import PeanoNat.
-  Require Import Nat.
-
   Lemma doLeader_spec :
     forall st h os st' ms m t n pli plt es ci,
       doLeader st h = (os, st', ms) ->
@@ -362,8 +361,6 @@ Section AppendEntriesRequestLeaderLogs.
     eapply lift_prop; eauto using nextIndex_safety_invariant.
   Qed.
 
-  Require Import Omega.
-  
   Lemma nextIndex_sanity :
     forall net h h',
       refined_raft_intermediate_reachable net ->
@@ -427,8 +424,6 @@ Section AppendEntriesRequestLeaderLogs.
     intros. induction l; simpl in *; auto.
   Qed.
 
-  Require Import Omega.
-  
   Lemma findGtIndex_app_in_1 :
     forall l1 l2 e,
       sorted (l1 ++ l2) ->

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
 Require Import FunctionalExtensionality.
 
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Require Import CommonTheorems.

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -2,11 +2,8 @@ Require Import FunctionalExtensionality.
 
 Require Import Raft.
 
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 
-Require Import UpdateLemmas.
-Require Import DecompositionWithPostState.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 Require Import AppendEntriesRequestReplyCorrespondenceInterface.
 

--- a/raft-proofs/AppendEntriesRequestTermSanityProof.v
+++ b/raft-proofs/AppendEntriesRequestTermSanityProof.v
@@ -2,8 +2,6 @@ Require Import GhostSimulations.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 
 Require Import SortedInterface.
 Require Import AppendEntriesRequestTermSanityInterface.

--- a/raft-proofs/AppendEntriesRequestTermSanityProof.v
+++ b/raft-proofs/AppendEntriesRequestTermSanityProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
+++ b/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
+++ b/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
@@ -1,7 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -1,14 +1,6 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
-Require Import Permutation.
 
-Require Import Net.
 Require Import GhostSimulations.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -1,11 +1,12 @@
 Require Import Nat.
 
 Require Import GhostSimulations.
+
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-
-Require Import Raft.
 Require Import CommonTheorems.
 Require Import StateMachineSafetyInterface.
 Require Import SortedInterface.

--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import InverseTraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import InverseTraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/CandidateEntriesProof.v
+++ b/raft-proofs/CandidateEntriesProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/CandidateTermGtLogProof.v
+++ b/raft-proofs/CandidateTermGtLogProof.v
@@ -1,6 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/CandidateTermGtLogProof.v
+++ b/raft-proofs/CandidateTermGtLogProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import CommonTheorems.

--- a/raft-proofs/CandidatesVoteForSelvesProof.v
+++ b/raft-proofs/CandidatesVoteForSelvesProof.v
@@ -1,15 +1,7 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import CommonTheorems.
-Require Import StructTact.StructTactics.
 
 Require Import CandidatesVoteForSelvesInterface.
 

--- a/raft-proofs/CandidatesVoteForSelvesProof.v
+++ b/raft-proofs/CandidatesVoteForSelvesProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -1,7 +1,4 @@
-Require Import Nat.
-
 Require Import TraceRelations.
-Require Import UpdateLemmas.
 
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import TraceRelations.
 Require Import UpdateLemmas.
 

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -1,7 +1,6 @@
 Require Import NPeano.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CandidatesVoteForSelvesInterface.

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -1,7 +1,4 @@
-Require Import NPeano.
-
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CandidatesVoteForSelvesInterface.

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -1,6 +1,7 @@
 Require Import NPeano.
 
 Require Import GhostSimulations.
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CandidatesVoteForSelvesInterface.

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -1,18 +1,10 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CandidatesVoteForSelvesInterface.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 Require Import VotesCorrectInterface.
 

--- a/raft-proofs/CroniesTermProof.v
+++ b/raft-proofs/CroniesTermProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/CurrentTermGtZeroProof.v
+++ b/raft-proofs/CurrentTermGtZeroProof.v
@@ -1,6 +1,4 @@
 Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import SpecLemmas.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/CurrentTermGtZeroProof.v
+++ b/raft-proofs/CurrentTermGtZeroProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import TraceUtil.
 Require Import Linearizability.
 
 Require Import RaftLinearizableProofs.
@@ -110,12 +109,6 @@ Require Import AllEntriesVotesWithLogProof.
 
 Require Import VotesWithLogSortedInterface.
 Require Import VotesWithLogSortedProof.
-
-Require Import TermsAndIndicesFromOneInterface.
-Require Import TermsAndIndicesFromOneProof.
-
-Require Import LeaderLogsLogMatchingInterface.
-Require Import LeaderLogsLogMatchingProof.
 
 Require Import LeaderLogsLogMatchingInterface.
 Require Import LeaderLogsLogMatchingProof.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -1,7 +1,4 @@
-Require Import Nat.
-
 Require Import Raft.
-Require Import CommonTheorems.
 Require Import TraceUtil.
 Require Import Linearizability.
 

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -1,14 +1,4 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
-Require Import Sorting.Permutation.
-
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -316,7 +316,6 @@ Hint Extern 4 (@leaderLogs_votesWithLog_interface _ _ _) => apply llvwli : typec
 Hint Extern 4 (@allEntries_log_interface _ _ _) => apply aeli : typeclass_instances.
 Hint Extern 4 (@allEntries_votesWithLog_interface _ _ _) => apply aevwli : typeclass_instances.
 Hint Extern 4 (@votesWithLog_sorted_interface _ _ _) => apply vwlsi : typeclass_instances.
-Hint Extern 4 (@terms_and_indices_from_one_interface _ _ _) => apply taifoi : typeclass_instances.
 Hint Extern 4 (@leaderLogs_entries_match_interface _ _ _) => apply lllmi : typeclass_instances.
 Hint Extern 4 (@state_machine_safety'interface _ _ _) => apply sms'i : typeclass_instances.
 Hint Extern 4 (@append_entries_leaderLogs_interface _ _ _) => apply aerlli : typeclass_instances.

--- a/raft-proofs/EveryEntryWasCreatedHostLogProof.v
+++ b/raft-proofs/EveryEntryWasCreatedHostLogProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Require Import LeadersHaveLeaderLogsInterface.
 Require Import EveryEntryWasCreatedInterface.

--- a/raft-proofs/EveryEntryWasCreatedHostLogProof.v
+++ b/raft-proofs/EveryEntryWasCreatedHostLogProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/EveryEntryWasCreatedProof.v
+++ b/raft-proofs/EveryEntryWasCreatedProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import RefinementCommonDefinitions.
 
 Require Import LeadersHaveLeaderLogsInterface.

--- a/raft-proofs/EveryEntryWasCreatedProof.v
+++ b/raft-proofs/EveryEntryWasCreatedProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/GhostLogAllEntriesProof.v
+++ b/raft-proofs/GhostLogAllEntriesProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/GhostLogAllEntriesProof.v
+++ b/raft-proofs/GhostLogAllEntriesProof.v
@@ -1,9 +1,6 @@
 Require Import GhostSimulations.
 
 Require Import Raft.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 Require Import RaftRefinementInterface.
 Require Import RaftMsgRefinementInterface.

--- a/raft-proofs/GhostLogCorrectProof.v
+++ b/raft-proofs/GhostLogCorrectProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/GhostLogCorrectProof.v
+++ b/raft-proofs/GhostLogCorrectProof.v
@@ -1,10 +1,8 @@
 Require Import GhostSimulations.
 
 Require Import Raft.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
 Require Import RaftMsgRefinementInterface.
 
 Require Import NextIndexSafetyInterface.

--- a/raft-proofs/GhostLogLogMatchingProof.v
+++ b/raft-proofs/GhostLogLogMatchingProof.v
@@ -3,7 +3,6 @@ Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import RaftMsgRefinementInterface.
 
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import SpecLemmas.

--- a/raft-proofs/GhostLogLogMatchingProof.v
+++ b/raft-proofs/GhostLogLogMatchingProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/GhostLogsLogPropertiesProof.v
+++ b/raft-proofs/GhostLogsLogPropertiesProof.v
@@ -1,12 +1,9 @@
 Require Import GhostSimulations.
 
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import Raft.
 Require Import RaftMsgRefinementInterface.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
-Require Import SpecLemmas.
 
 Require Import GhostLogsLogPropertiesInterface.
 

--- a/raft-proofs/GhostLogsLogPropertiesProof.v
+++ b/raft-proofs/GhostLogsLogPropertiesProof.v
@@ -1,15 +1,8 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import CommonDefinitions.
 Require Import CommonTheorems.
-Require Import StructTact.StructTactics.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import RaftMsgRefinementInterface.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/InLogInAllEntriesProof.v
+++ b/raft-proofs/InLogInAllEntriesProof.v
@@ -2,7 +2,6 @@ Require Import Raft.
 Require Import RaftRefinementInterface.
 
 Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/InLogInAllEntriesProof.v
+++ b/raft-proofs/InLogInAllEntriesProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import GhostSimulations.
 Require Import InverseTraceRelations.
 Require Import UpdateLemmas.

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -1,13 +1,6 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
 Require Import GhostSimulations.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import InverseTraceRelations.
 Require Import UpdateLemmas.
 

--- a/raft-proofs/LastAppliedCommitIndexMatchingProof.v
+++ b/raft-proofs/LastAppliedCommitIndexMatchingProof.v
@@ -1,8 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft-proofs/LastAppliedLeCommitIndexProof.v
+++ b/raft-proofs/LastAppliedLeCommitIndexProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import Raft.
 
 Require Import LastAppliedLeCommitIndexInterface.

--- a/raft-proofs/LastAppliedLeCommitIndexProof.v
+++ b/raft-proofs/LastAppliedLeCommitIndexProof.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
 Require Import Nat.
-Require Import Arith.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 
 Require Import Raft.
 

--- a/raft-proofs/LeaderCompletenessProof.v
+++ b/raft-proofs/LeaderCompletenessProof.v
@@ -1,12 +1,4 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Sumbool.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 
 Require Import Raft.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeaderCompletenessProof.v
+++ b/raft-proofs/LeaderCompletenessProof.v
@@ -1,7 +1,6 @@
 Require Import Sumbool.
 
 Require Import Raft.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/LeaderLogsCandidateEntriesProof.v
+++ b/raft-proofs/LeaderLogsCandidateEntriesProof.v
@@ -1,7 +1,8 @@
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.
 Require Import CommonTheorems.

--- a/raft-proofs/LeaderLogsCandidateEntriesProof.v
+++ b/raft-proofs/LeaderLogsCandidateEntriesProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/LeaderLogsCandidateEntriesProof.v
+++ b/raft-proofs/LeaderLogsCandidateEntriesProof.v
@@ -4,9 +4,7 @@ Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
-Require Import RefinementCommonDefinitions.
 Require Import RefinementCommonTheorems.
 
 Require Import CandidateEntriesInterface.

--- a/raft-proofs/LeaderLogsContiguousProof.v
+++ b/raft-proofs/LeaderLogsContiguousProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/LeaderLogsContiguousProof.v
+++ b/raft-proofs/LeaderLogsContiguousProof.v
@@ -5,13 +5,10 @@ Require Import RaftRefinementInterface.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import LeaderLogsContiguousInterface.
 Require Import LogMatchingInterface.
-
-Require Import SpecLemmas.
 
 Section LeaderLogsContiguous.
 

--- a/raft-proofs/LeaderLogsLogMatchingProof.v
+++ b/raft-proofs/LeaderLogsLogMatchingProof.v
@@ -2,7 +2,6 @@ Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import SpecLemmas.

--- a/raft-proofs/LeaderLogsLogMatchingProof.v
+++ b/raft-proofs/LeaderLogsLogMatchingProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/LeaderLogsLogPropertiesProof.v
+++ b/raft-proofs/LeaderLogsLogPropertiesProof.v
@@ -1,14 +1,6 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import CommonDefinitions.
 Require Import CommonTheorems.
-Require Import StructTact.StructTactics.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import RaftRefinementInterface.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/LeaderLogsLogPropertiesProof.v
+++ b/raft-proofs/LeaderLogsLogPropertiesProof.v
@@ -1,5 +1,3 @@
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import UpdateLemmas.

--- a/raft-proofs/LeaderLogsPreservedProof.v
+++ b/raft-proofs/LeaderLogsPreservedProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeaderLogsPreservedProof.v
+++ b/raft-proofs/LeaderLogsPreservedProof.v
@@ -1,10 +1,7 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import RefinementCommonDefinitions.
 Require Import CommonTheorems.
 Require Import RefinementCommonTheorems.
-Require Import SpecLemmas.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/LeaderLogsSortedProof.v
+++ b/raft-proofs/LeaderLogsSortedProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/LeaderLogsSublogProof.v
+++ b/raft-proofs/LeaderLogsSublogProof.v
@@ -1,7 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import SpecLemmas.

--- a/raft-proofs/LeaderLogsSublogProof.v
+++ b/raft-proofs/LeaderLogsSublogProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/LeaderLogsTermSanityProof.v
+++ b/raft-proofs/LeaderLogsTermSanityProof.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
-Require Import Omega.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/LeaderLogsTermSanityProof.v
+++ b/raft-proofs/LeaderLogsTermSanityProof.v
@@ -2,7 +2,6 @@ Require Import GhostSimulations.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -127,8 +127,6 @@ Section LeaderLogsVotesWithLog.
   Qed.
 
 
-  Require Import Omega.
-  
   Lemma wonElection_dedup_spec :
     forall l,
       wonElection (dedup name_eq_dec l) = true ->

--- a/raft-proofs/LeaderSublogProof.v
+++ b/raft-proofs/LeaderSublogProof.v
@@ -1,16 +1,7 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
-Require Import Omega.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 Require Import OneLeaderPerTermInterface.
 

--- a/raft-proofs/LeaderSublogProof.v
+++ b/raft-proofs/LeaderSublogProof.v
@@ -11,11 +11,11 @@ Require Import VotesCorrectInterface.
 Require Import CroniesCorrectInterface.
 Require Import RefinementCommonTheorems.
 
+Require Import LeaderSublogInterface.
+
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.
 Hint Extern 4 (@FailureParams _ _) => apply failure_params : typeclass_instances.
-
-Require Import LeaderSublogInterface.
 
 Section LeaderSublogProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeaderSublogProof.v
+++ b/raft-proofs/LeaderSublogProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -1,8 +1,5 @@
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -1,9 +1,6 @@
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
-Require Import SpecLemmas.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/LogAllEntriesProof.v
+++ b/raft-proofs/LogAllEntriesProof.v
@@ -2,7 +2,6 @@ Require Import Raft.
 Require Import RaftRefinementInterface.
 
 Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/LogAllEntriesProof.v
+++ b/raft-proofs/LogAllEntriesProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -1,15 +1,6 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import SpecLemmas.
 Require Import CommonTheorems.

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -8,11 +8,11 @@ Require Import SortedInterface.
 Require Import UniqueIndicesInterface.
 Require Import LeaderSublogInterface.
 
+Require Import LogMatchingInterface.
+
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.
 Hint Extern 4 (@FailureParams _ _) => apply failure_params : typeclass_instances.
-
-Require Import LogMatchingInterface.
 
 Section LogMatchingProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import Raft.
 
 Require Import SpecLemmas.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -1,10 +1,7 @@
-Require Import PeanoNat.
-Require Import Nat.
 Require Import GhostSimulations.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Require Import SpecLemmas.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -1,3 +1,5 @@
+Require Import PeanoNat.
+Require Import Nat.
 Require Import GhostSimulations.
 
 Require Import Raft.
@@ -581,9 +583,6 @@ Section LogsLeaderLogs.
       repeat find_higher_order_rewrite;
       update_destruct; subst; rewrite_update; eauto.
   Qed.
-
-  Require Import PeanoNat.
-  Require Import Nat.
 
   Lemma doLeader_spec :
     forall st h os st' ms m t n pli plt es ci,

--- a/raft-proofs/MatchIndexAllEntriesProof.v
+++ b/raft-proofs/MatchIndexAllEntriesProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/MatchIndexLeaderProof.v
+++ b/raft-proofs/MatchIndexLeaderProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/MatchIndexLeaderProof.v
+++ b/raft-proofs/MatchIndexLeaderProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Require Import CommonTheorems.

--- a/raft-proofs/MatchIndexSanityProof.v
+++ b/raft-proofs/MatchIndexSanityProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Require Import CommonTheorems.

--- a/raft-proofs/NextIndexSafetyProof.v
+++ b/raft-proofs/NextIndexSafetyProof.v
@@ -1,13 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Arith.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/NoAppendEntriesRepliesToSelfProof.v
+++ b/raft-proofs/NoAppendEntriesRepliesToSelfProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import SpecLemmas.
 

--- a/raft-proofs/NoAppendEntriesToLeaderProof.v
+++ b/raft-proofs/NoAppendEntriesToLeaderProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/NoAppendEntriesToSelfProof.v
+++ b/raft-proofs/NoAppendEntriesToSelfProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import SpecLemmas.
 

--- a/raft-proofs/OneLeaderLogPerTermProof.v
+++ b/raft-proofs/OneLeaderLogPerTermProof.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
-Require Import Omega.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/OneLeaderLogPerTermProof.v
+++ b/raft-proofs/OneLeaderLogPerTermProof.v
@@ -2,7 +2,6 @@ Require Import GhostSimulations.
 
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.

--- a/raft-proofs/OneLeaderPerTermProof.v
+++ b/raft-proofs/OneLeaderPerTermProof.v
@@ -1,15 +1,6 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
-Require Import StructTact.StructTactics.
 Require Import Raft.
 
 Require Import CommonTheorems.

--- a/raft-proofs/OneLeaderPerTermProof.v
+++ b/raft-proofs/OneLeaderPerTermProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import GhostSimulations.
 Require Import Raft.
 

--- a/raft-proofs/OutputCorrectProof.v
+++ b/raft-proofs/OutputCorrectProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/OutputCorrectProof.v
+++ b/raft-proofs/OutputCorrectProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -1,5 +1,3 @@
-Require Import Nat.
-
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
 
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import TraceRelations.
 
 Require Import Raft.

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import UpdateLemmas.

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -1,10 +1,10 @@
 Require Import GhostSimulations.
 
+Require Import Raft.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-
-Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.
 Require Import CommonTheorems.

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -6,7 +6,6 @@ Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -1345,8 +1345,6 @@ Section PrefixWithinTerm.
     eapply lift_prop; eauto using nextIndex_safety_invariant.
   Qed.
 
-  Require Import Omega.
-  
   Lemma nextIndex_sanity :
     forall net h h',
       refined_raft_intermediate_reachable net ->

--- a/raft-proofs/PrevLogCandidateEntriesTermProof.v
+++ b/raft-proofs/PrevLogCandidateEntriesTermProof.v
@@ -1,15 +1,6 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
-Require Import Omega.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/PrevLogCandidateEntriesTermProof.v
+++ b/raft-proofs/PrevLogCandidateEntriesTermProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import Raft.
 Require Import CommonTheorems.
 Require Import SpecLemmas.

--- a/raft-proofs/PrevLogLeaderSublogProof.v
+++ b/raft-proofs/PrevLogLeaderSublogProof.v
@@ -3,6 +3,7 @@ Require Import Raft.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RaftRefinementInterface.
+Require Import RefinementCommonDefinitions.
 
 Require Import PrevLogCandidateEntriesTermInterface.
 Require Import VotesCorrectInterface.

--- a/raft-proofs/PrevLogLeaderSublogProof.v
+++ b/raft-proofs/PrevLogLeaderSublogProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft-proofs/PrevLogLeaderSublogProof.v
+++ b/raft-proofs/PrevLogLeaderSublogProof.v
@@ -1,16 +1,7 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
-Require Import Omega.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -5,6 +5,7 @@ Require Import FunctionalExtensionality.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
+Require Import DupDropReordering.
 Require Import SpecLemmas.
 
 Require Import RaftRefinementInterface.
@@ -659,8 +660,6 @@ Section RaftMsgRefinement.
     intros.
     eauto using simulation_1.
   Qed.
-
-  Require Import DupDropReordering.
 
   Lemma step_f_star_raft_intermediate_reachable_extend :
     forall f net f' net' tr,

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -3,6 +3,7 @@ Require Import Sumbool.
 Require Import FunctionalExtensionality.
 
 Require Import GhostSimulations.
+Require Import RaftState.
 Require Import Raft.
 Require Import SpecLemmas.
 

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -1,9 +1,6 @@
-Require Import NPeano.
-Require Import Sumbool.
 Require Import FunctionalExtensionality.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 Require Import DupDropReordering.
 Require Import SpecLemmas.

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -3,7 +3,6 @@ Require Import Sumbool.
 Require Import FunctionalExtensionality.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 Require Import SpecLemmas.
 

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -1,18 +1,10 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 Require Import Sumbool.
 Require Import FunctionalExtensionality.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import SpecLemmas.
 
 Require Import RaftRefinementInterface.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -2,7 +2,6 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -2,6 +2,7 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
+Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -1,9 +1,6 @@
-Require Import NPeano.
-Require Import Sumbool.
 Require Import FunctionalExtensionality.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -1,5 +1,6 @@
 Require Import NPeano.
 Require Import Sumbool.
+Require Import FunctionalExtensionality.
 
 Require Import GhostSimulations.
 Require Import RaftState.
@@ -412,8 +413,6 @@ Section RaftRefinementProof.
       eapply RRIR_doGenericServer; eauto.
   Qed.
 
-  Require Import FunctionalExtensionality.
-
   Ltac workhorse :=
     try match goal with
         | [ |- mkNetwork _ _ = mkNetwork _ _ ] => f_equal
@@ -507,8 +506,6 @@ Section RaftRefinementProof.
     intros.
     eauto using simulation_1.
   Qed.
-
-  Require Import FunctionalExtensionality.
 
   Theorem simulation_2 :
     forall net,

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -1,17 +1,9 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 Require Import Sumbool.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import RaftRefinementInterface.
 

--- a/raft-proofs/RefinedLogMatchingLemmasProof.v
+++ b/raft-proofs/RefinedLogMatchingLemmasProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
+++ b/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
@@ -1,12 +1,10 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
 
 Require Import RequestVoteMaxIndexMaxTermInterface.
 Require Import RequestVoteTermSanityInterface.

--- a/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
+++ b/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
+++ b/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
+++ b/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
@@ -1,13 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/RequestVoteReplyTermSanityProof.v
+++ b/raft-proofs/RequestVoteReplyTermSanityProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/RequestVoteReplyTermSanityProof.v
+++ b/raft-proofs/RequestVoteReplyTermSanityProof.v
@@ -1,12 +1,9 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
 
 Require Import RequestVoteTermSanityInterface.
 Require Import RequestVoteReplyTermSanityInterface.

--- a/raft-proofs/RequestVoteTermSanityProof.v
+++ b/raft-proofs/RequestVoteTermSanityProof.v
@@ -1,11 +1,9 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import SpecLemmas.
-Require Import CommonTheorems.
 
 Require Import RequestVoteTermSanityInterface.
 

--- a/raft-proofs/RequestVoteTermSanityProof.v
+++ b/raft-proofs/RequestVoteTermSanityProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/SortedProof.v
+++ b/raft-proofs/SortedProof.v
@@ -1,6 +1,5 @@
 Require Import NPeano.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/SortedProof.v
+++ b/raft-proofs/SortedProof.v
@@ -1,6 +1,3 @@
-Require Import NPeano.
-
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/SortedProof.v
+++ b/raft-proofs/SortedProof.v
@@ -1,5 +1,6 @@
 Require Import NPeano.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/SortedProof.v
+++ b/raft-proofs/SortedProof.v
@@ -1,16 +1,7 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
-Require Import Omega.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 
 Require Import SpecLemmas.

--- a/raft-proofs/StateMachineCorrectProof.v
+++ b/raft-proofs/StateMachineCorrectProof.v
@@ -1,12 +1,4 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 
 Require Import StateMachineCorrectInterface.
 

--- a/raft-proofs/StateMachineCorrectProof.v
+++ b/raft-proofs/StateMachineCorrectProof.v
@@ -1,14 +1,11 @@
-Require Import Nat.
-
 Require Import Raft.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import CommonDefinitions.
 Require Import SpecLemmas.
 Require Import CommonTheorems.
-Require Import SpecLemmas.
+
 Require Import SortedInterface.
 Require Import DecompositionWithPostState.
 Require Import MaxIndexSanityInterface.

--- a/raft-proofs/StateMachineCorrectProof.v
+++ b/raft-proofs/StateMachineCorrectProof.v
@@ -1,11 +1,10 @@
 Require Import Nat.
 
-Require Import StateMachineCorrectInterface.
+Require Import Raft.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import Raft.
 Require Import CommonDefinitions.
 Require Import SpecLemmas.
 Require Import CommonTheorems.
@@ -15,6 +14,7 @@ Require Import DecompositionWithPostState.
 Require Import MaxIndexSanityInterface.
 Require Import StateMachineSafetyInterface.
 Require Import LogMatchingInterface.
+Require Import StateMachineCorrectInterface.
 
 Section StateMachineCorrect.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/StateMachineSafetyPrimeProof.v
+++ b/raft-proofs/StateMachineSafetyPrimeProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import CommonTheorems.

--- a/raft-proofs/StateMachineSafetyPrimeProof.v
+++ b/raft-proofs/StateMachineSafetyPrimeProof.v
@@ -16,9 +16,7 @@ Require Import LeaderLogsLogMatchingInterface.
 Require Import LogsLeaderLogsInterface.
 Require Import OneLeaderLogPerTermInterface.
 Require Import RefinedLogMatchingLemmasInterface.
-Require Import SpecLemmas.
 
-Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Section StateMachineSafety'.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,6 +1,5 @@
 Require Import GhostSimulations.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 Require Import CommitRecordedCommittedInterface.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,4 +1,5 @@
 Require Import GhostSimulations.
+Require Import FunctionalExtensionality.
 
 Require Import RaftState.
 Require Import Raft.
@@ -3121,8 +3122,6 @@ Section StateMachineSafetyProof.
       + eapply state_machine_safety'_state_same_packet_subset; eauto.
         auto using state_machine_safety'_invariant, msg_simulation_1.
   Qed.
-
-  Require Import FunctionalExtensionality.
 
   Lemma everything_reboot :
     msg_refined_raft_net_invariant_reboot' everything.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,7 +1,5 @@
 Require Import GhostSimulations.
-Require Import FunctionalExtensionality.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 Require Import CommitRecordedCommittedInterface.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import RaftState.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,5 +1,6 @@
 Require Import GhostSimulations.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 Require Import CommitRecordedCommittedInterface.

--- a/raft-proofs/TermSanityProof.v
+++ b/raft-proofs/TermSanityProof.v
@@ -1,6 +1,5 @@
 Require Import NPeano.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/TermSanityProof.v
+++ b/raft-proofs/TermSanityProof.v
@@ -1,6 +1,3 @@
-Require Import NPeano.
-
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/TermSanityProof.v
+++ b/raft-proofs/TermSanityProof.v
@@ -1,15 +1,7 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import CommonTheorems.
 
 Require Import TermSanityInterface.

--- a/raft-proofs/TermSanityProof.v
+++ b/raft-proofs/TermSanityProof.v
@@ -1,5 +1,6 @@
 Require Import NPeano.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft-proofs/TermsAndIndicesFromOneLogProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneLogProof.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import SpecLemmas.
 

--- a/raft-proofs/TermsAndIndicesFromOneLogProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneLogProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import CommonTheorems.

--- a/raft-proofs/TermsAndIndicesFromOneProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/TransitiveCommitProof.v
+++ b/raft-proofs/TransitiveCommitProof.v
@@ -1,11 +1,5 @@
-Require Import Sumbool.
-
 Require Import Raft.
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import RaftRefinementInterface.
-
-Require Import RefinementCommonDefinitions.
 
 Require Import LeaderCompletenessInterface.
 Require Import RefinedLogMatchingLemmasInterface.

--- a/raft-proofs/TransitiveCommitProof.v
+++ b/raft-proofs/TransitiveCommitProof.v
@@ -1,12 +1,4 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Sumbool.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 
 Require Import Raft.
 Require Import CommonDefinitions.

--- a/raft-proofs/UniqueIndicesProof.v
+++ b/raft-proofs/UniqueIndicesProof.v
@@ -1,15 +1,6 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import SortedInterface.
 

--- a/raft-proofs/UniqueIndicesProof.v
+++ b/raft-proofs/UniqueIndicesProof.v
@@ -1,5 +1,3 @@
-Require Import NPeano.
-
 Require Import Raft.
 
 Require Import SortedInterface.

--- a/raft-proofs/VotedForMoreUpToDateProof.v
+++ b/raft-proofs/VotedForMoreUpToDateProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/VotedForMoreUpToDateProof.v
+++ b/raft-proofs/VotedForMoreUpToDateProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/VotedForTermSanityProof.v
+++ b/raft-proofs/VotedForTermSanityProof.v
@@ -1,12 +1,10 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
 
 Require Import RequestVoteTermSanityInterface.
 Require Import VotedForTermSanityInterface.

--- a/raft-proofs/VotedForTermSanityProof.v
+++ b/raft-proofs/VotedForTermSanityProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -1,13 +1,5 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -10,8 +10,6 @@ Require Import RefinementSpecLemmas.
 Require Import RaftUpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import StructTact.StructTactics.
-
 Require Import VotesCorrectInterface.
 Require Import VotesLeCurrentTermInterface.
 

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -1,9 +1,5 @@
-Require Import NPeano.
-
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -1,5 +1,6 @@
 Require Import NPeano.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -1,6 +1,5 @@
 Require Import NPeano.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.

--- a/raft-proofs/VotesLeCurrentTermProof.v
+++ b/raft-proofs/VotesLeCurrentTermProof.v
@@ -1,9 +1,5 @@
-Require Import NPeano.
-
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft-proofs/VotesLeCurrentTermProof.v
+++ b/raft-proofs/VotesLeCurrentTermProof.v
@@ -1,5 +1,6 @@
 Require Import NPeano.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.

--- a/raft-proofs/VotesLeCurrentTermProof.v
+++ b/raft-proofs/VotesLeCurrentTermProof.v
@@ -1,6 +1,5 @@
 Require Import NPeano.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonTheorems.

--- a/raft-proofs/VotesLeCurrentTermProof.v
+++ b/raft-proofs/VotesLeCurrentTermProof.v
@@ -1,13 +1,5 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
@@ -17,8 +9,6 @@ Require Import RefinementSpecLemmas.
 
 Require Import RaftUpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
-
-Require Import StructTact.StructTactics.
 
 Require Import VotesLeCurrentTermInterface.
 

--- a/raft-proofs/VotesReceivedMoreUpToDateProof.v
+++ b/raft-proofs/VotesReceivedMoreUpToDateProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/VotesReceivedMoreUpToDateProof.v
+++ b/raft-proofs/VotesReceivedMoreUpToDateProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/VotesVotesWithLogCorrespondProof.v
+++ b/raft-proofs/VotesVotesWithLogCorrespondProof.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/VotesVotesWithLogCorrespondProof.v
+++ b/raft-proofs/VotesVotesWithLogCorrespondProof.v
@@ -1,8 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft-proofs/VotesWithLogSortedProof.v
+++ b/raft-proofs/VotesWithLogSortedProof.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 
 Require Import Raft.

--- a/raft-proofs/VotesWithLogTermSanityProof.v
+++ b/raft-proofs/VotesWithLogTermSanityProof.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-Require Import Omega.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft-proofs/VotesWithLogTermSanityProof.v
+++ b/raft-proofs/VotesWithLogTermSanityProof.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 

--- a/raft/AllEntriesCandidateEntriesInterface.v
+++ b/raft/AllEntriesCandidateEntriesInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/AllEntriesCandidateEntriesInterface.v
+++ b/raft/AllEntriesCandidateEntriesInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.

--- a/raft/AllEntriesIndicesGt0Interface.v
+++ b/raft/AllEntriesIndicesGt0Interface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section AllEntriesIndicesGt0.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesIndicesGt0Interface.v
+++ b/raft/AllEntriesIndicesGt0Interface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/AllEntriesLeaderLogsInterface.v
+++ b/raft/AllEntriesLeaderLogsInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AllEntriesLeaderLogsTermInterface.v
+++ b/raft/AllEntriesLeaderLogsTermInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AllEntriesLeaderSublogInterface.v
+++ b/raft/AllEntriesLeaderSublogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AllEntriesLogInterface.v
+++ b/raft/AllEntriesLogInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AllEntriesLogMatchingInterface.v
+++ b/raft/AllEntriesLogMatchingInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AllEntriesTermSanityInterface.v
+++ b/raft/AllEntriesTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section AllEntriesTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesTermSanityInterface.v
+++ b/raft/AllEntriesTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/AllEntriesVotesWithLogInterface.v
+++ b/raft/AllEntriesVotesWithLogInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AppendEntriesLeaderInterface.v
+++ b/raft/AppendEntriesLeaderInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/AppendEntriesReplySublogInterface.v
+++ b/raft/AppendEntriesReplySublogInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Section AppendEntriesReplySublog.

--- a/raft/AppendEntriesRequestLeaderLogsInterface.v
+++ b/raft/AppendEntriesRequestLeaderLogsInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section AppendEntriesRequestLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesRequestLeaderLogsInterface.v
+++ b/raft/AppendEntriesRequestLeaderLogsInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
+++ b/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-Require Import Omega.
 Require Import FunctionalExtensionality.
 
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 

--- a/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
+++ b/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
@@ -1,5 +1,3 @@
-Require Import FunctionalExtensionality.
-
 Require Import Raft.
 
 

--- a/raft/AppendEntriesRequestTermSanityInterface.v
+++ b/raft/AppendEntriesRequestTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/AppendEntriesRequestTermSanityInterface.v
+++ b/raft/AppendEntriesRequestTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section AppendEntriesRequestTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesRequestsCameFromLeadersInterface.v
+++ b/raft/AppendEntriesRequestsCameFromLeadersInterface.v
@@ -1,13 +1,5 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section AppendEntriesRequestsCameFromLeaders.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppliedEntriesMonotonicInterface.v
+++ b/raft/AppliedEntriesMonotonicInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/AppliedImpliesInputInterface.v
+++ b/raft/AppliedImpliesInputInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/CandidateEntriesInterface.v
+++ b/raft/CandidateEntriesInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Export CommonDefinitions.
 Require Export RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.

--- a/raft/CandidateEntriesInterface.v
+++ b/raft/CandidateEntriesInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Export CommonDefinitions.

--- a/raft/CandidateEntriesInterface.v
+++ b/raft/CandidateEntriesInterface.v
@@ -1,6 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Export RefinementCommonDefinitions.
+Require Import RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CandidateTermGtLogInterface.v
+++ b/raft/CandidateTermGtLogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Section CandidateTermGtLogInterface.

--- a/raft/CandidatesVoteForSelvesInterface.v
+++ b/raft/CandidatesVoteForSelvesInterface.v
@@ -1,4 +1,3 @@
-Require Import Net.
 Require Import Raft.
 
 Section CandidatesVoteForSelvesInterface.

--- a/raft/CausalOrderPreservedInterface.v
+++ b/raft/CausalOrderPreservedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/CommitRecordedCommittedInterface.v
+++ b/raft/CommitRecordedCommittedInterface.v
@@ -1,9 +1,4 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import GhostSimulations.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import LeaderCompletenessInterface.

--- a/raft/CommonDefinitions.v
+++ b/raft/CommonDefinitions.v
@@ -1,5 +1,3 @@
-Require Import PeanoNat.
-
 Require Import Raft.
 
 Section CommonDefinitions.

--- a/raft/CommonDefinitions.v
+++ b/raft/CommonDefinitions.v
@@ -1,11 +1,5 @@
-Require Import List.
-Import ListNotations.
-
 Require Import PeanoNat.
-Require Import Arith.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 
 Section CommonDefinitions.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -2,7 +2,6 @@ Require Import NPeano.
 Require Import PeanoNat.
 Import Nat.
 
-Require Import RaftState.
 Require Import Raft.
 
 Require Import UpdateLemmas.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1,18 +1,9 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import Omega.
 Require Import PeanoNat.
 Import Nat.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -2,6 +2,7 @@ Require Import NPeano.
 Require Import PeanoNat.
 Import Nat.
 
+Require Import RaftState.
 Require Import Raft.
 
 Require Import UpdateLemmas.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1,5 +1,4 @@
 Require Import PeanoNat.
-Import Nat.
 
 Require Import RaftState.
 Require Import Raft.
@@ -1956,7 +1955,7 @@ Section CommonTheorems.
     intros. unfold contiguous_range_exact_lo in *. intuition.
     - invc H4.
       + eexists; intuition.
-      + find_rewrite. find_apply_lem_hyp succ_inj. subst.
+      + find_rewrite. find_apply_lem_hyp Nat.succ_inj. subst.
         assert (i < i0 <= maxIndex (y :: l)). simpl. omega.
         find_apply_hyp_hyp. break_exists. simpl in *.
         intuition; subst; eexists; intuition.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1,4 +1,3 @@
-Require Import NPeano.
 Require Import PeanoNat.
 Import Nat.
 

--- a/raft/CroniesCorrectInterface.v
+++ b/raft/CroniesCorrectInterface.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/CroniesCorrectInterface.v
+++ b/raft/CroniesCorrectInterface.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/CroniesCorrectInterface.v
+++ b/raft/CroniesCorrectInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft/CroniesTermInterface.v
+++ b/raft/CroniesTermInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import RaftRefinementInterface.
 Require Import Raft.
 

--- a/raft/CurrentTermGtZeroInterface.v
+++ b/raft/CurrentTermGtZeroInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/CurrentTermGtZeroInterface.v
+++ b/raft/CurrentTermGtZeroInterface.v
@@ -1,7 +1,5 @@
 Require Import Raft.
 
-Require Import CommonDefinitions.
-
 Section CurrentTermGtZeroInterface.
   Context {orig_base_params : BaseParams}.
   Context {one_node_params : OneNodeParams orig_base_params}.

--- a/raft/DecompositionWithPostState.v
+++ b/raft/DecompositionWithPostState.v
@@ -1,9 +1,5 @@
-Require Import List.
 Require Import FunctionalExtensionality.
 
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 
 Section DecompositionWithPostState.

--- a/raft/EveryEntryWasCreatedHostLogInterface.v
+++ b/raft/EveryEntryWasCreatedHostLogInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import RefinementCommonDefinitions.
 
 Section EveryEntryWasCreatedHostLogInterface.

--- a/raft/EveryEntryWasCreatedHostLogInterface.v
+++ b/raft/EveryEntryWasCreatedHostLogInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/EveryEntryWasCreatedInterface.v
+++ b/raft/EveryEntryWasCreatedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/GhostLogAllEntriesInterface.v
+++ b/raft/GhostLogAllEntriesInterface.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft/GhostLogAllEntriesInterface.v
+++ b/raft/GhostLogAllEntriesInterface.v
@@ -1,12 +1,5 @@
-Require Import Arith.
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import RaftRefinementInterface.
 Require Import RaftMsgRefinementInterface.

--- a/raft/GhostLogAllEntriesInterface.v
+++ b/raft/GhostLogAllEntriesInterface.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft/GhostLogCorrectInterface.v
+++ b/raft/GhostLogCorrectInterface.v
@@ -1,12 +1,5 @@
-Require Import Arith.
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import RaftMsgRefinementInterface.
 

--- a/raft/GhostLogCorrectInterface.v
+++ b/raft/GhostLogCorrectInterface.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftMsgRefinementInterface.

--- a/raft/GhostLogCorrectInterface.v
+++ b/raft/GhostLogCorrectInterface.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftMsgRefinementInterface.

--- a/raft/GhostLogLogMatchingInterface.v
+++ b/raft/GhostLogLogMatchingInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftMsgRefinementInterface.
 

--- a/raft/GhostLogsLogPropertiesInterface.v
+++ b/raft/GhostLogsLogPropertiesInterface.v
@@ -1,5 +1,3 @@
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import Raft.
 Require Import RaftMsgRefinementInterface.
 

--- a/raft/GhostLogsLogPropertiesInterface.v
+++ b/raft/GhostLogsLogPropertiesInterface.v
@@ -1,13 +1,6 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import RaftMsgRefinementInterface.
 
 Section GhostLogsLogProperties.

--- a/raft/InLogInAllEntriesInterface.v
+++ b/raft/InLogInAllEntriesInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/InputBeforeOutputInterface.v
+++ b/raft/InputBeforeOutputInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/InputBeforeOutputInterface.v
+++ b/raft/InputBeforeOutputInterface.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 Require Import TraceUtil.
 
 Section InputBeforeOutputInterface.

--- a/raft/LastAppliedCommitIndexMatchingInterface.v
+++ b/raft/LastAppliedCommitIndexMatchingInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 
 Section LastAppliedCommitIndexMatching.

--- a/raft/LastAppliedLeCommitIndexInterface.v
+++ b/raft/LastAppliedLeCommitIndexInterface.v
@@ -1,5 +1,3 @@
-Require Import CommonDefinitions.
-
 Require Import Raft.
 
 Section LastAppliedLeCommitIndexInterface.

--- a/raft/LastAppliedLeCommitIndexInterface.v
+++ b/raft/LastAppliedLeCommitIndexInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import CommonDefinitions.
 
 Require Import Raft.

--- a/raft/LeaderCompletenessInterface.v
+++ b/raft/LeaderCompletenessInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LeaderLogsCandidateEntriesInterface.v
+++ b/raft/LeaderLogsCandidateEntriesInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LeaderLogsCandidateEntriesInterface.v
+++ b/raft/LeaderLogsCandidateEntriesInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 Require Import RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.

--- a/raft/LeaderLogsContiguousInterface.v
+++ b/raft/LeaderLogsContiguousInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LeaderLogsContiguousInterface.v
+++ b/raft/LeaderLogsContiguousInterface.v
@@ -1,7 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import CommonDefinitions.
 Require Import CommonTheorems.
 
 Section LeaderLogsContiguous.

--- a/raft/LeaderLogsLogMatchingInterface.v
+++ b/raft/LeaderLogsLogMatchingInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LeaderLogsLogPropertiesInterface.v
+++ b/raft/LeaderLogsLogPropertiesInterface.v
@@ -1,16 +1,11 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import CommonDefinitions.
 Require Import CommonTheorems.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 Require Import RaftRefinementInterface.
+
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
+
 Require Import SpecLemmas.
 Require Import RefinementSpecLemmas.
 Require Import RefinedLogMatchingLemmasInterface.

--- a/raft/LeaderLogsLogPropertiesInterface.v
+++ b/raft/LeaderLogsLogPropertiesInterface.v
@@ -1,14 +1,5 @@
-Require Import CommonDefinitions.
-Require Import CommonTheorems.
 Require Import Raft.
 Require Import RaftRefinementInterface.
-
-Require Import UpdateLemmas.
-Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
-
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import RefinedLogMatchingLemmasInterface.
 
 Section LeaderLogsLogProperties.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsPreservedInterface.v
+++ b/raft/LeaderLogsPreservedInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section LeaderLogsPreserved.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsPreservedInterface.v
+++ b/raft/LeaderLogsPreservedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LeaderLogsSortedInterface.v
+++ b/raft/LeaderLogsSortedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LeaderLogsSublogInterface.v
+++ b/raft/LeaderLogsSublogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LeaderLogsTermSanityInterface.v
+++ b/raft/LeaderLogsTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LeaderLogsTermSanityInterface.v
+++ b/raft/LeaderLogsTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section LeaderLogsTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsVotesWithLogInterface.v
+++ b/raft/LeaderLogsVotesWithLogInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section LeaderLogsVotesWithLog.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsVotesWithLogInterface.v
+++ b/raft/LeaderLogsVotesWithLogInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LeaderSublogInterface.v
+++ b/raft/LeaderSublogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Section LeaderSublogInterface.

--- a/raft/LeadersHaveLeaderLogsInterface.v
+++ b/raft/LeadersHaveLeaderLogsInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LeadersHaveLeaderLogsStrongInterface.v
+++ b/raft/LeadersHaveLeaderLogsStrongInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/Linearizability.v
+++ b/raft/Linearizability.v
@@ -156,7 +156,6 @@ Section Linearizability.
     induction 1; intros; simpl in *; intuition.
   Qed.
 
-  Require Import Permutation.
   Hint Constructors Permutation.
   Lemma IR_equiv_Permutation :
     forall ir1 ir2,

--- a/raft/Linearizability.v
+++ b/raft/Linearizability.v
@@ -1,10 +1,4 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-
-Require Import VerdiHints.
+Require Import Verdi.
 
 Section Linearizability.
   Variable K : Type.

--- a/raft/LogAllEntriesInterface.v
+++ b/raft/LogAllEntriesInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/LogMatchingInterface.v
+++ b/raft/LogMatchingInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/LogsLeaderLogsInterface.v
+++ b/raft/LogsLeaderLogsInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/LogsLeaderLogsInterface.v
+++ b/raft/LogsLeaderLogsInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section LogsLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft/MatchIndexAllEntriesInterface.v
+++ b/raft/MatchIndexAllEntriesInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/MatchIndexLeaderInterface.v
+++ b/raft/MatchIndexLeaderInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Section MatchIndexLeader.

--- a/raft/MatchIndexSanityInterface.v
+++ b/raft/MatchIndexSanityInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Section MatchIndexSanity.

--- a/raft/MaxIndexSanityInterface.v
+++ b/raft/MaxIndexSanityInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import CommonDefinitions.
 
 Require Import Raft.

--- a/raft/MaxIndexSanityInterface.v
+++ b/raft/MaxIndexSanityInterface.v
@@ -1,5 +1,3 @@
-Require Import CommonDefinitions.
-
 Require Import Raft.
 
 Section MaxIndexSanity.

--- a/raft/NextIndexSafetyInterface.v
+++ b/raft/NextIndexSafetyInterface.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 
 Section NextIndexSafety.
   Context {orig_base_params : BaseParams}.

--- a/raft/NextIndexSafetyInterface.v
+++ b/raft/NextIndexSafetyInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft/NoAppendEntriesRepliesToSelfInterface.v
+++ b/raft/NoAppendEntriesRepliesToSelfInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft/NoAppendEntriesRepliesToSelfInterface.v
+++ b/raft/NoAppendEntriesRepliesToSelfInterface.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 
 Section NoAppendEntriesRepliesToSelfInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesToLeaderInterface.v
+++ b/raft/NoAppendEntriesToLeaderInterface.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 
 Section NoAppendEntriesToLeaderInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesToLeaderInterface.v
+++ b/raft/NoAppendEntriesToLeaderInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft/NoAppendEntriesToSelfInterface.v
+++ b/raft/NoAppendEntriesToSelfInterface.v
@@ -1,5 +1,4 @@
 Require Import Raft.
-Require Import CommonDefinitions.
 
 Section NoAppendEntriesToSelfInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesToSelfInterface.v
+++ b/raft/NoAppendEntriesToSelfInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft/OneLeaderLogPerTermInterface.v
+++ b/raft/OneLeaderLogPerTermInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/OneLeaderLogPerTermInterface.v
+++ b/raft/OneLeaderLogPerTermInterface.v
@@ -1,8 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
 
-Require Import CommonDefinitions.
-
 Section OneLeaderLogPerTerm.
 
   Context {orig_base_params : BaseParams}.

--- a/raft/OneLeaderPerTermInterface.v
+++ b/raft/OneLeaderPerTermInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Section OneLeaderPerTermInterface.

--- a/raft/OutputCorrectInterface.v
+++ b/raft/OutputCorrectInterface.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/OutputGreatestIdInterface.v
+++ b/raft/OutputGreatestIdInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/OutputImpliesAppliedInterface.v
+++ b/raft/OutputImpliesAppliedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 Require Import TraceUtil.

--- a/raft/PrefixWithinTermInterface.v
+++ b/raft/PrefixWithinTermInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/PrevLogCandidateEntriesTermInterface.v
+++ b/raft/PrevLogCandidateEntriesTermInterface.v
@@ -1,6 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Export RefinementCommonDefinitions.
+Require Import RefinementCommonDefinitions.
 
 Section PrevLogCandidateEntriesTermInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/PrevLogCandidateEntriesTermInterface.v
+++ b/raft/PrevLogCandidateEntriesTermInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Export CommonDefinitions.
 Require Export RefinementCommonDefinitions.
 
 Section PrevLogCandidateEntriesTermInterface.

--- a/raft/PrevLogCandidateEntriesTermInterface.v
+++ b/raft/PrevLogCandidateEntriesTermInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Export CommonDefinitions.

--- a/raft/PrevLogLeaderSublogInterface.v
+++ b/raft/PrevLogLeaderSublogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Section PrevLogLeaderSublogInterface.

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -1,15 +1,4 @@
-Require Import Arith.
-Require Import NPeano.
-Require Import PeanoNat.
-Import Nat.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
-
-Require Import StructTact.Util.
-Require Import Net.
-Require Import StructTact.StructTactics.
+Require Export Verdi.
 Require Import RaftState.
 
 Open Scope bool.
@@ -35,10 +24,10 @@ Section Raft.
   Definition name_eq_dec : forall x y : name, {x = y} + {x <> y} := fin_eq_dec _.
 
   
-  Notation "a >? b" := (b <? a) (at level 42).
-  Notation "a >=? b" := (b <=? a) (at level 42).
-  Notation "a == b" := (beq_nat a b) (at level 42).
-  Notation "a != b" := (negb (beq_nat a b)) (at level 42).
+  Notation "a >? b" := (b <? a) (at level 70).
+  Notation "a >=? b" := (b <=? a) (at level 70).
+  Notation "a == b" := (beq_nat a b) (at level 70).
+  Notation "a != b" := (negb (beq_nat a b)) (at level 70).
 
   Notation "a === b" := (if fin_eq_dec _ a b then true else false) (at level 42).
   
@@ -370,7 +359,7 @@ Section Raft.
     (list raft_output * raft_data * list (name * msg)) :=
     let (out, state) :=
         applyEntries h state
-                     (rev (filter (fun x => andb (ltb (lastApplied state) (eIndex x))
+                     (rev (filter (fun x => andb (Nat.ltb (lastApplied state) (eIndex x))
                                                 (leb (eIndex x) (commitIndex state)))
                                   (findGtIndex (log state) (lastApplied state)))) in
     (out, {[ state with lastApplied := if commitIndex state >? lastApplied state then
@@ -391,7 +380,7 @@ Section Raft.
              (currentTerm state) me prevIndex prevTerm newEntries (commitIndex state)).
 
   Definition haveQuorum (state : raft_data) (me : name) (N : logIndex) : bool :=
-    ltb (div2 (length nodes)) (length (filter (fun h => leb N (assoc_default name_eq_dec (matchIndex state) h 0)) nodes)).
+    Nat.ltb (div2 (length nodes)) (length (filter (fun h => leb N (assoc_default name_eq_dec (matchIndex state) h 0)) nodes)).
   
   Definition advanceCommitIndex (state : raft_data) (me : name) : raft_data :=
     let entriesToCommit :=

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -1,4 +1,5 @@
 Require Import Nat.
+Require Import Sumbool.
 
 Require Import Raft.
 Require Import CommonTheorems.
@@ -60,8 +61,6 @@ Section RaftLinearizableProofs.
                     exported env_i env_o l tr ->
                     exported env_i env_o (IRI k :: IRU k :: l) ((i, o) :: tr).
 
-  Require Import Sumbool.
-  Require Import Arith.
 
   Fixpoint get_input (tr : list (name * (raft_input + list raft_output))) (k : key)
     : option input :=

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -1,4 +1,3 @@
-Require Import Nat.
 Require Import Sumbool.
 
 Require Import Raft.
@@ -6,7 +5,6 @@ Require Import CommonTheorems.
 Require Import TraceUtil.
 Require Import Linearizability.
 Require Import OutputImpliesAppliedInterface.
-Require Import UniqueIndicesInterface.
 Require Import AppliedImpliesInputInterface.
 Require Import CausalOrderPreservedInterface.
 Require Import OutputCorrectInterface.

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -1,14 +1,4 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
 Require Import Nat.
-Require Import Omega.
-Require Import Sorting.Permutation.
-
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -2,7 +2,6 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -2,6 +2,7 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
+Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -1,8 +1,4 @@
-Require Import NPeano.
-Require Import Sumbool.
-
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Require Import RaftRefinementInterface.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -1,17 +1,9 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 Require Import Sumbool.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Require Import RaftRefinementInterface.
 

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -2,7 +2,6 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Section RaftRefinementInterface.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -1,8 +1,4 @@
-Require Import NPeano.
-Require Import Sumbool.
-
 Require Import GhostSimulations.
-Require Import RaftState.
 Require Import Raft.
 
 Section RaftRefinementInterface.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -1,17 +1,9 @@
-Require Import Arith.
 Require Import NPeano.
-Require Import List.
-Require Import Coq.Numbers.Natural.Abstract.NDiv.
-Import ListNotations.
-Require Import Sorting.Permutation.
 Require Import Sumbool.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import RaftState.
 Require Import Raft.
-Require Import StructTact.StructTactics.
 
 Section RaftRefinementInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -2,6 +2,7 @@ Require Import NPeano.
 Require Import Sumbool.
 
 Require Import GhostSimulations.
+Require Import RaftState.
 Require Import Raft.
 
 Section RaftRefinementInterface.

--- a/raft/RaftUpdateLemmas.v
+++ b/raft/RaftUpdateLemmas.v
@@ -1,3 +1,4 @@
+Require Import RaftState.
 Require Import Raft.
 
 Require Export UpdateLemmas.

--- a/raft/RaftUpdateLemmas.v
+++ b/raft/RaftUpdateLemmas.v
@@ -1,4 +1,3 @@
-Require Import RaftState.
 Require Import Raft.
 
 Require Export UpdateLemmas.

--- a/raft/RaftUpdateLemmas.v
+++ b/raft/RaftUpdateLemmas.v
@@ -1,5 +1,3 @@
-Require Import StructTact.Util.
-Require Import Net.
 Require Import RaftState.
 Require Import Raft.
 

--- a/raft/RefinedLogMatchingLemmasInterface.v
+++ b/raft/RefinedLogMatchingLemmasInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import CommonTheorems.
 
 Require Import Raft.

--- a/raft/RefinementCommonDefinitions.v
+++ b/raft/RefinementCommonDefinitions.v
@@ -1,5 +1,3 @@
-Require Import PeanoNat.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/RefinementCommonDefinitions.v
+++ b/raft/RefinementCommonDefinitions.v
@@ -1,11 +1,5 @@
-Require Import List.
-Import ListNotations.
-
 Require Import PeanoNat.
-Require Import Arith.
 
-Require Import StructTact.Util.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/RefinementCommonTheorems.v
+++ b/raft/RefinementCommonTheorems.v
@@ -6,7 +6,7 @@ Require Import VotesCorrectInterface.
 Require Import CroniesCorrectInterface.
 
 Require Import CommonTheorems.
-Require Import RefinementCommonDefinitions.
+Require Export RefinementCommonDefinitions.
 
 Require Import SpecLemmas.
 

--- a/raft/RefinementCommonTheorems.v
+++ b/raft/RefinementCommonTheorems.v
@@ -1,5 +1,3 @@
-Require Import PeanoNat.
-
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft/RefinementCommonTheorems.v
+++ b/raft/RefinementCommonTheorems.v
@@ -1,12 +1,5 @@
-Require Import List.
-Import ListNotations.
-
 Require Import PeanoNat.
-Require Import Arith.
 
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 Require Import GhostSimulations.
 Require Import Raft.
 Require Import RaftRefinementInterface.

--- a/raft/RefinementSpecLemmas.v
+++ b/raft/RefinementSpecLemmas.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
 Require Import Min.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft/RefinementSpecLemmas.v
+++ b/raft/RefinementSpecLemmas.v
@@ -1,5 +1,3 @@
-Require Import Min.
-
 Require Import Raft.
 Require Import CommonTheorems.
 Require Import RaftRefinementInterface.

--- a/raft/RequestVoteMaxIndexMaxTermInterface.v
+++ b/raft/RequestVoteMaxIndexMaxTermInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section RequestVoteMaxIndexMaxTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft/RequestVoteMaxIndexMaxTermInterface.v
+++ b/raft/RequestVoteMaxIndexMaxTermInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/RequestVoteReplyMoreUpToDateInterface.v
+++ b/raft/RequestVoteReplyMoreUpToDateInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section RequestVoteReplyMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/RequestVoteReplyMoreUpToDateInterface.v
+++ b/raft/RequestVoteReplyMoreUpToDateInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/RequestVoteReplyTermSanityInterface.v
+++ b/raft/RequestVoteReplyTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/RequestVoteTermSanityInterface.v
+++ b/raft/RequestVoteTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/RequestVoteTermSanityInterface.v
+++ b/raft/RequestVoteTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section RequestVoteTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/SortedInterface.v
+++ b/raft/SortedInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1,6 +1,5 @@
 Require Import Min.
 
-Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1,5 +1,6 @@
 Require Import Min.
 
+Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.
 

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1,5 +1,3 @@
-Require Import Min.
-
 Require Import RaftState.
 Require Import Raft.
 Require Import CommonTheorems.

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1,11 +1,4 @@
-Require Import List.
-Import ListNotations.
 Require Import Min.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
 
 Require Import RaftState.
 Require Import Raft.

--- a/raft/StateMachineCorrectInterface.v
+++ b/raft/StateMachineCorrectInterface.v
@@ -1,11 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
-
 Require Import Raft.
 Require Import CommonDefinitions.
 

--- a/raft/StateMachineSafetyInterface.v
+++ b/raft/StateMachineSafetyInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import CommonDefinitions.
 
 Require Import Raft.

--- a/raft/StateMachineSafetyPrimeInterface.v
+++ b/raft/StateMachineSafetyPrimeInterface.v
@@ -1,9 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Net.
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 Require Import CommonDefinitions.
 
 Require Import Raft.

--- a/raft/StateMachineSafetyPrimeInterface.v
+++ b/raft/StateMachineSafetyPrimeInterface.v
@@ -1,5 +1,3 @@
-Require Import CommonDefinitions.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import LeaderCompletenessInterface.

--- a/raft/StateTraceInvariant.v
+++ b/raft/StateTraceInvariant.v
@@ -1,10 +1,6 @@
-Require Import List.
-Import ListNotations.
-
 Require Import FunctionalExtensionality.
 
-Require Import StructTact.StructTactics.
-Require Import Net.
+Require Import Verdi.
 
 Section ST.
   Context {B : BaseParams}.

--- a/raft/TermSanityInterface.v
+++ b/raft/TermSanityInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Section TermSanityInterface.

--- a/raft/TermsAndIndicesFromOneInterface.v
+++ b/raft/TermsAndIndicesFromOneInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/TermsAndIndicesFromOneLogInterface.v
+++ b/raft/TermsAndIndicesFromOneLogInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/TraceUtil.v
+++ b/raft/TraceUtil.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-Require Import Arith.
-
-Require Import Net.
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
 Require Import Raft.
 
 Section TraceUtil.

--- a/raft/TransitiveCommitInterface.v
+++ b/raft/TransitiveCommitInterface.v
@@ -1,8 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
-Require Import StructTact.Util.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import LeaderCompletenessInterface.

--- a/raft/TransitiveCommitInterface.v
+++ b/raft/TransitiveCommitInterface.v
@@ -1,7 +1,6 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import LeaderCompletenessInterface.
-Require Import CommonDefinitions.
 
 Section TransitiveCommit.
 

--- a/raft/UniqueIndicesInterface.v
+++ b/raft/UniqueIndicesInterface.v
@@ -1,5 +1,3 @@
-Require Import List.
-Require Import Net.
 Require Import Raft.
 
 Require Import CommonDefinitions.

--- a/raft/VotedForMoreUpToDateInterface.v
+++ b/raft/VotedForMoreUpToDateInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section VotedForMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotedForMoreUpToDateInterface.v
+++ b/raft/VotedForMoreUpToDateInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotedForTermSanityInterface.v
+++ b/raft/VotedForTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section VotedForTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotedForTermSanityInterface.v
+++ b/raft/VotedForTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotesCorrectInterface.v
+++ b/raft/VotesCorrectInterface.v
@@ -1,7 +1,3 @@
-Require Import List.
-
-Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/VotesLeCurrentTermInterface.v
+++ b/raft/VotesLeCurrentTermInterface.v
@@ -1,6 +1,3 @@
-Require Import List.
-
-Require Import Net.
 Require Import Raft.
 Require Import RaftRefinementInterface.
 

--- a/raft/VotesReceivedMoreUpToDateInterface.v
+++ b/raft/VotesReceivedMoreUpToDateInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotesReceivedMoreUpToDateInterface.v
+++ b/raft/VotesReceivedMoreUpToDateInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section VotesReceivedMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesVotesWithLogCorrespondInterface.v
+++ b/raft/VotesVotesWithLogCorrespondInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotesVotesWithLogCorrespondInterface.v
+++ b/raft/VotesVotesWithLogCorrespondInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section VotesVotesWithLogCorrespond.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesWithLogSortedInterface.v
+++ b/raft/VotesWithLogSortedInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotesWithLogTermSanityInterface.v
+++ b/raft/VotesWithLogTermSanityInterface.v
@@ -1,10 +1,3 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
-
 Require Import Raft.
 Require Import RaftRefinementInterface.
 Require Import CommonDefinitions.

--- a/raft/VotesWithLogTermSanityInterface.v
+++ b/raft/VotesWithLogTermSanityInterface.v
@@ -1,6 +1,5 @@
 Require Import Raft.
 Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
 
 Section VotesWithLogTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/script/find-bad-imports.sh
+++ b/script/find-bad-imports.sh
@@ -14,7 +14,7 @@ function find-redundant-imports {
 
     sed -nE '/^[[:space:]]*(Require)?[[:space:]]+(Export)/p' "$FILE_OF_IMPORTS" | while read line
     do
-        find-line "." "$EXCLUDE_PATH_REGEX" "$line"
+        find-line "." "$EXCLUDE_PATH_REGEX" "${line//Export/Import}"
     done
 }
 

--- a/script/find-bad-imports.sh
+++ b/script/find-bad-imports.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+function find-line {
+    DIR=$1; shift
+    EXCLUDE_PATH_REGEX=$1; shift
+    LINE=$1; shift
+
+    find -E "$DIR" -name '*.v' \( -not -regex "$EXCLUDE_PATH_REGEX" \) -exec grep -Hni "$LINE" {} \+
+}
+
+function find-redundant-imports {
+    FILE_OF_IMPORTS=$1; shift
+    EXCLUDE_PATH_REGEX=$1; shift
+
+    sed -nE '/^[[:space:]]*(Require)?[[:space:]]+(Export)/p' "$FILE_OF_IMPORTS" | while read line
+    do
+        find-line "." "$EXCLUDE_PATH_REGEX" "$line"
+    done
+}
+
+echo "Looking for redundant imports."
+find-redundant-imports core/Verdi.v ".*/(core|lib)/.*"
+find-redundant-imports raft/Raft.v "(.*/(core|lib|systems)/.*)|(.*/Raft.v)"
+
+
+# Delete imports:
+# find . -proofs/ -name '*.v' \( -not -path '*/core/*' \) \
+#      -print -exec sed -ibak '/Require Import Net/d' {} \;
+
+echo "Looking for orphaned imports."
+find . -name '*.v' \( -not -path '*/lib/*' \)  -exec awk -f script/orphaned-imports.awk {} \;

--- a/script/find-unused-imports.sh
+++ b/script/find-unused-imports.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+function find_unused_imports_of_file {
+    FILE=$1; shift
+
+    echo "Considering file $FILE"
+
+    cp "$FILE" "${FILE}.bak"
+    N=0
+    while read line
+    do
+        N=$((N+1))
+        echo "read line $N:"
+        echo "$line"
+
+        # We assume that all imports happen at the top of the file.
+        # We allow blank lines and lines containing "Arguments" to be
+        # contained in the imports section.
+        if [[ "$line" =~ .*(Require|Import|Export|Arguments).*|^[[:space:]]*$ ]]
+        then
+            # Only check import statements for necessity, not blank
+            # lines or Arguments commands.
+            if [[ "$line" =~ .*(Require|Import|Export).* ]]
+            then
+                echo; echo; echo
+                echo "Testing whether $line is necessary"
+
+                sed -i "${N}d" "$FILE"
+
+                TARGET="$(dirname $FILE)/$(basename $FILE .v).vo"
+                rm -f "$TARGET"
+                make -f Makefile.coq "$TARGET"
+                exit_code=$?
+                if [[ $exit_code -eq 0 ]]
+                then
+                    echo "Build still passed with line $N removed from $FILE: "
+                    echo "$line"
+                fi
+                cp "${FILE}.bak" "$FILE"
+            fi
+        else
+            break
+        fi
+    done < "$FILE.bak"
+    rm -f "$FILE.bak"
+}
+
+git status | grep modified && { echo ERROR: working directory not clean; exit 1; }
+
+export -f find_unused_imports_of_file
+find . -name '*.v' -exec /bin/bash -c 'find_unused_imports_of_file "$0"' {} \;

--- a/script/orphaned-imports.awk
+++ b/script/orphaned-imports.awk
@@ -1,0 +1,20 @@
+BEGIN {
+    importing = 1
+
+    import_regex = "Require|Import|Export"
+}
+
+
+# many Verdi files contain an Arguments command in the middle of the imports
+# so we allow that here but do not count later occurences in the file
+# as violations of the "imports first" rule
+! ($0 ~ import_regex || /Arguments/ || /^[[:space:]]*$/) {
+  importing = 0 \
+}
+
+$0 ~ import_regex {
+    if (importing == 0) {
+        printf("Orphaned import in %s!\n", FILENAME)
+        printf("%s\n", $0)
+    }
+}

--- a/systems/Counter.v
+++ b/systems/Counter.v
@@ -1,13 +1,5 @@
-Require Import List.
-Import ListNotations.
-
-Require Import Arith.
-Require Import Omega.
-
-Require Import StructTact.StructTactics.
+Require Import Verdi.
 Require Import HandlerMonad.
-Require Import Net.
-Require Import StructTact.Util.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/systems/LockServ.v
+++ b/systems/LockServ.v
@@ -1,10 +1,5 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
+Require Import Verdi.
 Require Import HandlerMonad.
-Require Import Net.
-Require Import StructTact.Util.
 
 Require Import UpdateLemmas.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.

--- a/systems/LockServSeqNum.v
+++ b/systems/LockServSeqNum.v
@@ -1,5 +1,4 @@
-Require Import StructTact.StructTactics.
-Require Import Net.
+Require Import Verdi.
 
 Require Import LockServ.
 Require SeqNum.

--- a/systems/PrimaryBackup.v
+++ b/systems/PrimaryBackup.v
@@ -1,9 +1,4 @@
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
+Require Import Verdi.
 Require Import HandlerMonad.
 
 Require Import UpdateLemmas.

--- a/systems/SeqNum.v
+++ b/systems/SeqNum.v
@@ -1,12 +1,6 @@
-Require Import List.
-Require Import Arith.
-Require Import Omega.
-Import ListNotations.
-Require Import FunctionalExtensionality.
-Require Import StructTact.StructTactics.
+Require Import Verdi.
 
-Require Import Net.
-Require Import StructTact.Util.
+Require Import FunctionalExtensionality.
 
 Set Implicit Arguments.
 

--- a/systems/SeqNum.v
+++ b/systems/SeqNum.v
@@ -1,7 +1,5 @@
 Require Import Verdi.
 
-Require Import FunctionalExtensionality.
-
 Set Implicit Arguments.
 
 Section SeqNum.

--- a/systems/SeqNumCorrect.v
+++ b/systems/SeqNumCorrect.v
@@ -1,11 +1,7 @@
-Require Import List.
-Require Import Arith.
-Require Import Omega.
-Import ListNotations.
+Require Import Verdi.
+
 Require Import FunctionalExtensionality.
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-Require Import Net.
+
 Require Import SeqNum.
 
 Section SeqNumCorrect.

--- a/systems/VarD.v
+++ b/systems/VarD.v
@@ -1,4 +1,5 @@
 Require Import Verdi.
+Require Import StateMachineHandlerMonad.
 
 Require Import String.
 Require Import StringMap.
@@ -42,8 +43,6 @@ Definition data :=
 
 Definition beq_key (k1 k2 : key) :=
   if string_dec k1 k2 then true else false.
-
-Require Import StateMachineHandlerMonad.
 
 Definition getk k : GenHandler1 data (option value) :=
   db <- get ;;

--- a/systems/VarD.v
+++ b/systems/VarD.v
@@ -1,11 +1,4 @@
-Require Import Arith.
-Require Import List.
-Import ListNotations.
-
-Require Import StructTact.StructTactics.
-Require Import StructTact.Util.
-
-Require Import Net.
+Require Import Verdi.
 
 Require Import String.
 Require Import StringMap.

--- a/systems/VarD.v
+++ b/systems/VarD.v
@@ -1,8 +1,9 @@
 Require Import Verdi.
-Require Import StateMachineHandlerMonad.
 
 Require Import String.
 Require Import StringMap.
+
+Require Import StateMachineHandlerMonad.
 
 Definition key := string.
 Definition value := string.

--- a/systems/VarDPrimaryBackup.v
+++ b/systems/VarDPrimaryBackup.v
@@ -1,13 +1,9 @@
-Require Import Net.
+Require Import Verdi.
+
 Require Import VarD.
 Require Import PrimaryBackup.
 
-Require Import List.
-Import ListNotations.
 Open Scope string_scope.
-
-Require Import StructTact.Util.
-Require Import StructTact.StructTactics.
 
 Instance vard_pbj_params : PrimaryBackupParams vard_base_params :=
   {


### PR DESCRIPTION
This PR introduces a new file, `core/Verdi.v`, which exports modules that are typically imported by every file in Verdi. This file is further exported by `raft/Raft.v`. This allows many imports to be deleted across the codebase. 

The following rules are now followed: 
* No file should ever import `Nat` from the stdlib. It is meant to be used with fully qualified names.
* All `Require` statements should be at the top of the file (`script/find-bad-imports.sh` reports these "orphaned" imports)
* No file should import a module that is exported by a file it imports  (`script/find-bad-imports.sh` checks for these "redundant" imports purely syntactically)
* No file should import a module that it does not use (`script/find-unused-imports.sh` checks for these "unused" imports by attempting to delete each import one at a time and running the resulting build)