### PR TITLE
compatibility with decomposed StructTact

### DIFF
--- a/core/Verdi.v
+++ b/core/Verdi.v
@@ -10,3 +10,5 @@ Require Export StructTact.StructTactics.
 
 Require Export VerdiHints.
 Require Export Net.
+
+Require NPeano.


### PR DESCRIPTION
Some Raft proofs (e.g., StateMachineSafetyProof.v) currently depend on the fact that Util.v in StructTact contains Require Import NPeano.. To properly build Verdi against the StructTact resulting from my PR which decomposes Util.v and removes this line, Require NPeano. must be added somewhere in Verdi. Most simply, I here add it to Verdi.v. I've tested locally that the change enables building Verdi against the updated StructTact.

This change should not be merged until the StructTact PR is merged.