### PR TITLE
Compatibility with StructTact that exports stand-alone update

### DIFF
--- a/core/Simulations.v
+++ b/core/Simulations.v
@@ -2,8 +2,8 @@ Require Import List.
 Import ListNotations.
 
 Require Import StructTact.StructTactics.
-Require Import Net.
 Require Import StructTact.Util.
+Require Import Net.
 
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -1,8 +1,8 @@
 Require Import GhostSimulations.
 Require Import InverseTraceRelations.
-Require Import UpdateLemmas.
 
 Require Import Raft.
+Require Import UpdateLemmas.
 Require Import CommonTheorems.
 Require Import TraceUtil.
 


### PR DESCRIPTION
To make the Verdi update function usable outside of the standard network semantics, I extracted it to StructTact and exported it in a [related PR](https://github.com/uwplse/StructTact/pull/21). However, this necessitates changing some imports in Verdi to make sure the old update function is used in, e.g., Raft.

This should not be merged until after the related StructTact PR has been merged.