### PR TITLE
more informative naming of step relations

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -4,7 +4,7 @@ Filenames
 * CamlCase for Coq files, example: `StateMachineHandlerMonad.v`
 * CamlCase for OCaml files, example: `VarDArrangement.ml`
 * lowercase with dashes for scripts, example: `proof-linter.sh`
-* UPPERCASE with underscore for documentation, example: `PROOF_ENGINEERING.md`
+* UPPERCASE with underscores for documentation, example: `PROOF_ENGINEERING.md`
 
 Coq Files
 =========
@@ -44,6 +44,7 @@ Type Class Instances
 * field declaration with C-style naming on separate line indented by four spaces
 * one space between end of field declaration and semicolon
 
+Example:
 ```
 Instance base_params : BaseParams :=
   {
@@ -54,7 +55,7 @@ Instance base_params : BaseParams :=
 ```
 
 Theorems and Lemmas
-------
+-------------------
 
 * name uses underscore as separator
 * type declaration starts on a separate row
@@ -78,4 +79,28 @@ Proof.
     destruct (R_dec x');
       intuition eauto using T_monotonic, refl_trans_n1_1n_trace, R_implies_T.
 Qed.
+```
+
+Step Relation Definitions
+-------------------------
+
+* C-style name of (`Inductive`) type
+* each case starts with a bar
+* name of a case is the type name in CamelCase, followed by an underscore and a C-style identifier
+* body of a case is indented by four spaces
+
+Example:
+```
+Inductive step_async : step_relation network (name * (input + list output)) :=
+| StepAsync_deliver : forall net net' p xs ys out d l,
+    nwPackets net = xs ++ p :: ys ->
+    net_handlers (pDst p) (pSrc p) (pBody p) (nwState net (pDst p)) = (out, d, l) ->
+    net' = mkNetwork (send_packets (pDst p) l ++ xs ++ ys)
+                     (update name_eq_dec (nwState net) (pDst p) d) ->
+    step_async net net' [(pDst p, inr out)]
+| StepAsync_input : forall h net net' out inp d l,
+    input_handlers h inp (nwState net h) = (out, d, l) ->
+    net' = mkNetwork (send_packets h l ++ nwPackets net)
+                     (update name_eq_dec (nwState net) h d) ->
+    step_async net net' [(h, inl inp); (h, inr out)].
 ```

--- a/core/DupDropReordering.v
+++ b/core/DupDropReordering.v
@@ -213,13 +213,13 @@ Section dup_drop_reorder.
   Qed.
 End dup_drop_reorder.
 
-Section step_f_dup_drop_step.
+Section step_failure_dup_drop_step.
   Context `{params : FailureParams}.
 
-  Theorem step_f_dup_drop_step :
+  Theorem step_failure_dup_drop_step :
     forall ps ps' Sigma f,
       dup_drop_step_star _ ps ps' ->
-      step_f_star (f, mkNetwork ps Sigma) (f, mkNetwork ps' Sigma) [].
+      step_failure_star (f, mkNetwork ps Sigma) (f, mkNetwork ps' Sigma) [].
   Proof.
     induction 1.
     - constructor.
@@ -231,11 +231,11 @@ Section step_f_dup_drop_step.
         eapply RTn1TStep with (cs := []).
         * apply refl_trans_1n_n1_trace.
           apply IHclos_refl_trans_n1.
-        * eapply SF_dup; [simpl; eauto|]. auto.
+        * eapply StepFailure_dup; [simpl; eauto|]. auto.
       + apply refl_trans_n1_1n_trace.
         eapply RTn1TStep with (cs := []).
         * apply refl_trans_1n_n1_trace.
           apply IHclos_refl_trans_n1.
-        * eapply SF_drop; [simpl; eauto|]. auto.
+        * eapply StepFailure_drop; [simpl; eauto|]. auto.
   Qed.
-End step_f_dup_drop_step.
+End step_failure_dup_drop_step.

--- a/core/GhostSimulations.v
+++ b/core/GhostSimulations.v
@@ -172,10 +172,10 @@ Qed.
 
 Theorem ghost_simulation_1 :
   forall net net' failed failed' out,
-    @step_f _ _ refined_failure_params (failed, net) (failed', net') out ->
-    @step_f _ _ failure_params (failed, deghost net) (failed', deghost net') out.
+    @step_failure _ _ refined_failure_params (failed, net) (failed', net') out ->
+    @step_failure _ _ failure_params (failed, deghost net) (failed', deghost net') out.
 Proof.
-have H_sim := step_f_tot_mapped_simulation_1 ghost_tot_map_name_inv_inverse ghost_tot_map_name_inverse_inv ghost_eq_net_handlers_eq ghost_eq_input_handlers_eq ghost_tot_mapped_reboot_eq.
+have H_sim := step_failure_tot_mapped_simulation_1 ghost_tot_map_name_inv_inverse ghost_tot_map_name_inverse_inv ghost_eq_net_handlers_eq ghost_eq_input_handlers_eq ghost_tot_mapped_reboot_eq.
 move => net net' failed failed' out H_step.
 apply H_sim in H_step.
 rewrite /tot_map_name /tot_map_net /= 2!map_id /id /= in H_step.
@@ -200,13 +200,13 @@ Qed.
 
 Theorem ghost_simulation_2 :
   forall net net' failed failed' out gnet,
-    @step_f _ _ failure_params (failed, net) (failed', net') out ->
+    @step_failure _ _ failure_params (failed, net) (failed', net') out ->
     deghost gnet = net ->
     exists gnet',
-      step_f (failed, gnet) (failed', gnet') out /\
+      step_failure (failed, gnet) (failed', gnet') out /\
       deghost gnet' = net'.
 Proof.
-have H_sim := step_f_tot_mapped_simulation_2 ghost_tot_map_name_inv_inverse ghost_tot_map_name_inverse_inv ghost_eq_net_handlers_eq ghost_eq_input_handlers_eq ghost_tot_map_output_injective ghost_tot_mapped_reboot_eq.
+have H_sim := step_failure_tot_mapped_simulation_2 ghost_tot_map_name_inv_inverse ghost_tot_map_name_inverse_inv ghost_eq_net_handlers_eq ghost_eq_input_handlers_eq ghost_tot_map_output_injective ghost_tot_mapped_reboot_eq.
 move => net net' failed failed' out gnet H_step H_eq.
 apply (H_sim _ _ _ _ _ gnet failed failed' out) in H_step.
 - move: H_step => [gnet' [H_step H_eq_net]].
@@ -275,11 +275,11 @@ Qed.
 Theorem ghost_invariant_lift :
   forall P : _ -> Prop,
     (forall net net' failed failed' out,
-       @step_f _ _ failure_params (failed, net) (failed', net') out ->
+       @step_failure _ _ failure_params (failed, net) (failed', net') out ->
        P net ->
        P net') ->
     (forall net net' failed failed' out,
-       step_f (failed, net) (failed', net') out ->
+       step_failure (failed, net) (failed', net') out ->
        P (deghost net) ->
        P (deghost net')).
 Proof.
@@ -289,11 +289,11 @@ Qed.
 Theorem ghost_invariant_lower :
   forall P : _ -> Prop,
     (forall net net' failed failed' out,
-       step_f (failed, net) (failed', net') out ->
+       step_failure (failed, net) (failed', net') out ->
        P (deghost net) ->
        P (deghost net')) ->
     (forall net net' failed failed' out,
-       @step_f _ _ failure_params (failed, net) (failed', net') out ->
+       @step_failure _ _ failure_params (failed, net) (failed', net') out ->
        P net ->
        P net').
 Proof.
@@ -479,10 +479,10 @@ Qed.
 
 Theorem mgv_ghost_simulation_1 :
   forall net net' failed failed' out,
-    @step_f _ _ mgv_refined_failure_params (failed, net) (failed', net') out ->
-    @step_f _ _ failure_params (failed, mgv_deghost net) (failed', mgv_deghost net') out.
+    @step_failure _ _ mgv_refined_failure_params (failed, net) (failed', net') out ->
+    @step_failure _ _ failure_params (failed, mgv_deghost net) (failed', mgv_deghost net') out.
 Proof.
-have H_sim := step_f_tot_mapped_simulation_1 mgv_tot_map_name_inv_inverse mgv_tot_map_name_inverse_inv mgv_eq_net_handlers_eq mgv_eq_input_handlers_eq mgv_tot_mapped_reboot_eq.
+have H_sim := step_failure_tot_mapped_simulation_1 mgv_tot_map_name_inv_inverse mgv_tot_map_name_inverse_inv mgv_eq_net_handlers_eq mgv_eq_input_handlers_eq mgv_tot_mapped_reboot_eq.
 move => net net' failed failed' out H_step.
 apply H_sim in H_step.
 rewrite /tot_map_name /tot_map_net /= 2!map_id /id /= in H_step.
@@ -535,13 +535,13 @@ Qed.
 
 Theorem mgv_ghost_simulation_2 :
   forall net net' failed failed' out gnet,
-    @step_f _ _ failure_params (failed, net) (failed', net') out ->
+    @step_failure _ _ failure_params (failed, net) (failed', net') out ->
     mgv_deghost gnet = net ->
     exists gnet',
-      step_f (failed, gnet) (failed', gnet') out /\
+      step_failure (failed, gnet) (failed', gnet') out /\
       mgv_deghost gnet' = net'.
 Proof.
-have H_sim := step_f_tot_mapped_simulation_2 mgv_tot_map_name_inv_inverse mgv_tot_map_name_inverse_inv mgv_eq_net_handlers_eq mgv_eq_input_handlers_eq mgv_tot_map_output_injective mgv_tot_mapped_reboot_eq.
+have H_sim := step_failure_tot_mapped_simulation_2 mgv_tot_map_name_inv_inverse mgv_tot_map_name_inverse_inv mgv_eq_net_handlers_eq mgv_eq_input_handlers_eq mgv_tot_map_output_injective mgv_tot_mapped_reboot_eq.
 move => net net' failed failed' out gnet H_step H_eq.
 apply (H_sim _ _ _ _ _ gnet failed failed' out) in H_step.
 - move: H_step => [gnet' [H_step H_eq_net]].
@@ -581,11 +581,11 @@ Qed.
 Theorem mgv_ghost_invariant_lift :
   forall P : _ -> Prop,
     (forall net net' failed failed' out,
-       @step_f _ _ failure_params (failed, net) (failed', net') out ->
+       @step_failure _ _ failure_params (failed, net) (failed', net') out ->
        P net ->
        P net') ->
     (forall net net' failed failed' out,
-       step_f (failed, net) (failed', net') out ->
+       step_failure (failed, net) (failed', net') out ->
        P (mgv_deghost net) ->
        P (mgv_deghost net')).
 Proof.
@@ -595,11 +595,11 @@ Qed.
 Theorem mgv_ghost_invariant_lower :
   forall P : _ -> Prop,
     (forall net net' failed failed' out,
-       step_f (failed, net) (failed', net') out ->
+       step_failure (failed, net) (failed', net') out ->
        P (mgv_deghost net) ->
        P (mgv_deghost net')) ->
     (forall net net' failed failed' out,
-       @step_f _ _ failure_params (failed, net) (failed', net') out ->
+       @step_failure _ _ failure_params (failed, net) (failed', net') out ->
        P net ->
        P net').
 Proof.

--- a/core/StatePacketPacketDecomposition.v
+++ b/core/StatePacketPacketDecomposition.v
@@ -176,13 +176,13 @@ Section Decomposition.
   Qed.
 
   Theorem decomposition_invariant :
-    inductive_invariant step_m step_m_init composed_invariant.
+    inductive_invariant step_async step_async_init composed_invariant.
   Proof.
     unfold inductive_invariant. intuition.
     - unfold composed_invariant. simpl.
       intuition auto using state_invariant_init.
     - unfold inductive, composed_invariant. intros.
-      match goal with H : step_m _ _ _ |- _ => invcs H end; intuition; simpl in *.
+      match goal with H : step_async _ _ _ |- _ => invcs H end; intuition; simpl in *.
       + eauto using state_invariant_maintained_deliver.
       + find_apply_lem_hyp post_net_analyze_sent_packet.
         intuition

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -570,7 +570,7 @@ Section AppendEntriesRequestLeaderLogs.
   Lemma append_entries_leaderLogs_init :
     refined_raft_net_invariant_init append_entries_leaderLogs.
   Proof.
-    red. unfold append_entries_leaderLogs, step_m_init.
+    red. unfold append_entries_leaderLogs, step_async_init.
     intros. simpl in *. intuition.
   Qed.
 

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -170,7 +170,7 @@ Section AppendEntriesRequestReplyCorrespondence.
     exists (mkN ((nwPackets net) ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) (nwState net')).
     subst.
     exists pli,plt,ci,n. simpl in *; repeat find_rewrite; intuition.
-    eapply RIR_step_f with (net0 := net''); [|eapply SF_reboot with (h0 := h) (failed := [h])]; eauto;
+    eapply RIR_step_failure with (net0 := net''); [|eapply StepFailure_reboot with (h0 := h) (failed := [h])]; eauto;
     simpl; repeat find_rewrite; eauto.
     f_equal.
     apply functional_extensionality.
@@ -191,9 +191,9 @@ Section AppendEntriesRequestReplyCorrespondence.
     pose proof dup_drop_reorder _ packet_eq_dec _ _ ltac:(eauto).
     match goal with
     | [ H : dup_drop_step_star _ _ _ |- _ ] =>
-      eapply step_f_dup_drop_step with (f := []) (Sigma := nwState net) in H
+      eapply step_failure_dup_drop_step with (f := []) (Sigma := nwState net) in H
     end.
-    eapply step_f_star_raft_intermediate_reachable_extend with (f := []) (f' := []) (tr := []); [|eauto].
+    eapply step_failure_star_raft_intermediate_reachable_extend with (f := []) (f' := []) (tr := []); [|eauto].
     destruct net, net'. simpl in *. subst.
     auto.
   Qed.
@@ -273,7 +273,7 @@ Section AppendEntriesRequestReplyCorrespondence.
       intros. do_in_app. simpl in *.
       intuition; try find_apply_hyp_hyp; intuition; in_crush.
     - subst. simpl in *. subst. unfold exists_equivalent_network_with_aer.
-      find_eapply_lem_hyp RIR_step_f; [|eapply SF_dup with (failed := [])]; eauto.
+      find_eapply_lem_hyp RIR_step_failure; [|eapply StepFailure_dup with (failed := [])]; eauto.
       remember mkNetwork as mkN.
       remember mkPacket as mkP.
       unfold Net.name in *. simpl in *.

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -399,11 +399,11 @@ Section AppliedEntriesMonotonicProof.
   Theorem applied_entries_monotonic' :
     forall failed net failed' net' os,
       raft_intermediate_reachable net ->
-      (@step_f _ _ failure_params (failed, net) (failed', net') os) ->
+      (@step_failure _ _ failure_params (failed, net) (failed', net') os) ->
       exists es,
         applied_entries (nwState net') = applied_entries (nwState net) ++ es.
   Proof.
-    intros. match goal with H : step_f _ _ _ |- _ => invcs H end.
+    intros. match goal with H : step_failure _ _ _ |- _ => invcs H end.
     - unfold RaftNetHandler in *. repeat break_let. subst.
       find_inversion.
       match goal with
@@ -464,7 +464,7 @@ Section AppliedEntriesMonotonicProof.
   Theorem applied_entries_monotonic :
     forall e failed net failed' net' os,
       raft_intermediate_reachable net ->
-      (@step_f _ _ failure_params (failed, net) (failed', net') os) ->
+      (@step_failure _ _ failure_params (failed, net) (failed', net') os) ->
       In e (applied_entries (nwState net)) ->
       In e (applied_entries (nwState net')).
   Proof.

--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -245,14 +245,14 @@ Section AppliedImpliesInputProof.
     Lemma applied_implies_input_in_input_trace :
       forall net failed net' failed' tr,
         raft_intermediate_reachable net ->
-        @step_f _ _ failure_params (failed, net) (failed', net') tr ->
+        @step_failure _ _ failure_params (failed, net) (failed', net') tr ->
         ~ applied_implies_input_state client id i net ->
         applied_implies_input_state client id i net' ->
         in_input_trace client id i tr.
     Proof.
       intros.
       match goal with
-        | [ H : context [step_f _ _ _ ] |- _ ] => invcs H
+        | [ H : context [step_failure _ _ _ ] |- _ ] => invcs H
       end.
       - unfold RaftNetHandler in *. repeat break_let. subst. find_inversion.
         find_apply_lem_hyp applied_implies_input_update_split.
@@ -397,8 +397,8 @@ Section AppliedImpliesInputProof.
           right. intro. repeat (break_exists; intuition); eauto 10.
     Defined.
 
-    Instance ITR : InverseTraceRelation step_f :=
-      { init := step_f_init;
+    Instance ITR : InverseTraceRelation step_failure :=
+      { init := step_failure_init;
         R := fun s => applied_implies_input_state client id i (snd s);
         T := in_input_trace client id i
       }.
@@ -412,21 +412,21 @@ Section AppliedImpliesInputProof.
       apply in_input_trace_or_app. right.
       destruct s, s'. simpl in *.
       eapply applied_implies_input_in_input_trace; eauto.
-      eapply step_f_star_raft_intermediate_reachable; eauto.
+      eapply step_failure_star_raft_intermediate_reachable; eauto.
     Defined.
   End inner.
 
   Lemma applied_implies_input :
     forall client id failed net tr e,
-      @step_f_star _ _ failure_params step_f_init (failed, net) tr ->
+      @step_failure_star _ _ failure_params step_failure_init (failed, net) tr ->
       eClient e = client ->
       eId e = id ->
       applied_implies_input_state client id (eInput e) net ->
       in_input_trace client id (eInput e) tr.
   Proof.
     intros.
-    pose proof @inverse_trace_relations_work _ _ step_f (ITR client id (eInput e)) (failed, net) tr.
-    unfold step_f_star in *. simpl in *.
+    pose proof @inverse_trace_relations_work _ _ step_failure (ITR client id (eInput e)) (failed, net) tr.
+    unfold step_failure_star in *. simpl in *.
     auto.
   Qed.
 

--- a/raft-proofs/CandidatesVoteForSelvesProof.v
+++ b/raft-proofs/CandidatesVoteForSelvesProof.v
@@ -103,7 +103,7 @@ Section CandidatesVoteForSelvesProof.
   Theorem candidates_vote_for_selves_init :
     raft_net_invariant_init candidates_vote_for_selves.
   Proof.
-    unfold raft_net_invariant_init, candidates_vote_for_selves, step_m_init.
+    unfold raft_net_invariant_init, candidates_vote_for_selves, step_async_init.
     simpl in *. intros; discriminate.
   Qed.
 

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -35,7 +35,7 @@ Section CausalOrderPreserved.
   Lemma output_before_input_not_key_in_input_trace :
     forall tr tr' s s',
       ~ output_before_input client id client' id' tr ->
-      step_f s s' tr' ->
+      step_failure s s' tr' ->
       output_before_input client id client' id' (tr ++ tr') ->
       ~ exists i, in_input_trace client' id' i (tr ++ tr').
   Proof.
@@ -106,9 +106,9 @@ Section CausalOrderPreserved.
       + simpl in *. intuition.
   Qed.
   
-  Instance TR : TraceRelation step_f :=
+  Instance TR : TraceRelation step_failure :=
     {
-      init := step_f_init;
+      init := step_failure_init;
       T := output_before_input client id client' id';
       R := fun s => entries_ordered client id client' id' (snd s)
     }.
@@ -120,7 +120,7 @@ Section CausalOrderPreserved.
       destruct s as (failed, net).
       destruct s' as (failed', net'). simpl in *.
       unfold entries_ordered in *.
-      find_apply_lem_hyp step_f_star_raft_intermediate_reachable.
+      find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
       find_eapply_lem_hyp applied_entries_monotonic'; eauto.
       break_exists; repeat find_rewrite.
       eauto using before_func_app.
@@ -143,7 +143,7 @@ Section CausalOrderPreserved.
 
   Theorem causal_order_preserved :
     forall failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       output_before_input client id client' id' tr ->
       entries_ordered client id client' id' net.
   Proof.

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -689,7 +689,7 @@ Section CroniesCorrectProof.
   Lemma cronies_correct_init :
     refined_raft_net_invariant_init cronies_correct.
   Proof.
-    unfold refined_raft_net_invariant_init, cronies_correct, step_m_init.
+    unfold refined_raft_net_invariant_init, cronies_correct, step_async_init.
     unfold votes_received_cronies, cronies_votes, votes_nw, votes_received_leaders.
     simpl. intuition. discriminate.
   Qed.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -379,7 +379,7 @@ Section EndToEndProof.
   Theorem raft_linearizable :
     forall failed net tr,
       input_correct tr ->
-      step_f_star (params := failure_params) step_f_init (failed, net) tr ->
+      step_failure_star (params := failure_params) step_failure_init (failed, net) tr ->
       exists l tr1 st,
         equivalent _ (import tr) l /\
         exported (get_input tr) (get_output tr) l tr1 /\

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -479,7 +479,7 @@ Section InputBeforeOutput.
   Lemma in_applied_entries_step_applied_implies_input_state' :
     forall (failed : list name) net failed' net' o,
       raft_intermediate_reachable net ->
-      step_f (failed, net) (failed', net') o ->
+      step_failure (failed, net) (failed', net') o ->
       ~ in_applied_entries client id net ->
       in_applied_entries client id net' ->
       (exists e,
@@ -489,7 +489,7 @@ Section InputBeforeOutput.
       exists h o' inp,
         o = (h, inl (ClientRequest client id inp)) :: o'.
   Proof.
-    intros. match goal with H : step_f _ _ _ |- _ => invcs H end; intuition.
+    intros. match goal with H : step_failure _ _ _ |- _ => invcs H end; intuition.
     - left. unfold RaftNetHandler in *. repeat break_let. subst.
       unfold in_applied_entries in *.
       break_exists_exists. intuition.
@@ -569,9 +569,9 @@ Section InputBeforeOutput.
   
   Lemma in_applied_entries_step_applied_implies_input_state :
     forall (s : list name * network) s' tr o,
-      refl_trans_1n_trace step_f step_f_init s tr ->
+      refl_trans_1n_trace step_failure step_failure_init s tr ->
       ~ in_applied_entries client id (snd s) ->
-      step_f s s' o ->
+      step_failure s s' o ->
       in_applied_entries client id (snd s') ->
       (exists e,
         eClient e = client /\
@@ -583,7 +583,7 @@ Section InputBeforeOutput.
     intros.
     destruct s as (failed, net).
     destruct s' as (failed', net'). simpl in *.
-    find_apply_lem_hyp step_f_star_raft_intermediate_reachable.
+    find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
     eauto using in_applied_entries_step_applied_implies_input_state'.
   Qed.
 
@@ -633,9 +633,9 @@ Section InputBeforeOutput.
         eauto.
   Qed.
 
-  Instance TR : InverseTraceRelation step_f :=
+  Instance TR : InverseTraceRelation step_failure :=
     {
-      init := step_f_init;
+      init := step_failure_init;
       T := input_before_output client id;
       R := fun s => in_applied_entries client id (snd s) 
     }.
@@ -669,7 +669,7 @@ Section InputBeforeOutput.
 
   Theorem output_implies_input_before_output :
     forall failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       key_in_output_trace client id tr ->
       input_before_output client id tr.
   Proof.

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -120,7 +120,7 @@ Section LeadersHaveLeaderLogs.
   Lemma leaders_have_leaderLogs_init :
     refined_raft_net_invariant_init leaders_have_leaderLogs.
   Proof.
-    red. unfold leaders_have_leaderLogs, step_m_init.
+    red. unfold leaders_have_leaderLogs, step_async_init.
     intros. simpl in *. congruence.
   Qed.
 

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -245,7 +245,7 @@ Section LeadersHaveLeaderLogsStrong.
   Lemma leaders_have_leaderLogs_strong_init :
     refined_raft_net_invariant_init leaders_have_leaderLogs_strong.
   Proof.
-    red. unfold leaders_have_leaderLogs_strong, step_m_init.
+    red. unfold leaders_have_leaderLogs_strong, step_async_init.
     intros. simpl in *. congruence.
   Qed.
 

--- a/raft-proofs/OutputCorrectProof.v
+++ b/raft-proofs/OutputCorrectProof.v
@@ -823,12 +823,12 @@ Section OutputCorrect.
     forall failed failed' (net net' : network (params := @multi_params _ _ raft_params)) os,
       in_output_trace client id out os ->
       @raft_intermediate_reachable _ _ raft_params net ->
-      step_f (failed, net) (failed', net') os ->
+      step_failure (failed, net) (failed', net') os ->
       output_correct client id out (applied_entries (nwState net')).
   Proof.
     intros.
     match goal with
-      | [ H : context [ step_f _ _ _ ] |- _ ] => invcs H
+      | [ H : context [ step_failure _ _ _ ] |- _ ] => invcs H
     end.
     - unfold RaftNetHandler in *. repeat break_let. repeat find_inversion.
       find_apply_lem_hyp in_output_trace_singleton_inv.
@@ -860,9 +860,9 @@ Section OutputCorrect.
     - exfalso. eauto using in_output_trace_not_nil.
   Qed.
 
-  Instance TR : TraceRelation step_f :=
+  Instance TR : TraceRelation step_failure :=
     {
-      init := step_f_init;
+      init := step_failure_init;
       T := in_output_trace client id out ;
       T_dec := in_output_trace_dec ;
       R := fun s => let (_, net) := s in
@@ -871,7 +871,7 @@ Section OutputCorrect.
   Proof.
     - intros. repeat break_let. subst.
       find_eapply_lem_hyp applied_entries_monotonic';
-        eauto using step_f_star_raft_intermediate_reachable.
+        eauto using step_failure_star_raft_intermediate_reachable.
       unfold output_correct in *.
       break_exists.
       repeat find_rewrite.
@@ -887,12 +887,12 @@ Section OutputCorrect.
     break_let. subst.
     find_apply_lem_hyp in_output_changed; auto.
     destruct s.
-    eauto using in_output_trace_step_output_correct, step_f_star_raft_intermediate_reachable.
+    eauto using in_output_trace_step_output_correct, step_failure_star_raft_intermediate_reachable.
   Defined.
 
   Theorem output_correct :
     forall  failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       in_output_trace client id out tr ->
       output_correct client id out (applied_entries (nwState net)).
   Proof.

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -315,7 +315,7 @@ Section OutputGreatestId.
   Lemma output_implies_greatest :
     forall failed net failed' net' o client id id',
       raft_intermediate_reachable net ->
-      @step_f _ _ failure_params (failed, net) (failed', net') o ->
+      @step_failure _ _ failure_params (failed, net) (failed', net') o ->
       key_in_output_trace client id o ->
       id < id' ->
       before_func (has_key client id) (has_key client id') (applied_entries (nwState net')).
@@ -383,9 +383,9 @@ Section OutputGreatestId.
     Variable id_lt_id' : id < id'.
     
   
-    Instance TR : TraceRelation step_f :=
+    Instance TR : TraceRelation step_failure :=
       {
-        init := step_f_init;
+        init := step_failure_init;
         T := key_in_output_trace client id ;
         T_dec := key_in_output_trace_dec client id ;
         R := fun s => before_func (has_key client id) (has_key client id') (applied_entries (nwState (snd s)))
@@ -394,7 +394,7 @@ Section OutputGreatestId.
       - intros.
         destruct s as (failed, net).
         destruct s' as (failed', net'). simpl in *.
-        find_apply_lem_hyp step_f_star_raft_intermediate_reachable.
+        find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
         find_eapply_lem_hyp applied_entries_monotonic'; eauto.
         break_exists; repeat find_rewrite.
         eauto using before_func_app.
@@ -403,14 +403,14 @@ Section OutputGreatestId.
       - intros.
         destruct s as [failed net].
         destruct s' as [failed' net']. simpl in *.
-        find_apply_lem_hyp step_f_star_raft_intermediate_reachable.
+        find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
         find_apply_lem_hyp in_output_changed; auto.
         eauto using output_implies_greatest.
     Defined.
 
   Theorem output_greatest_id :
     forall failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       key_in_output_trace client id tr ->
       before_func (has_key client id) (has_key client id') (applied_entries (nwState net)).
   Proof.

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -160,7 +160,7 @@ Section OutputImpliesApplied.
   Lemma output_implies_in_applied_entries :
     forall failed net failed' net' o,
       raft_intermediate_reachable net ->
-      @step_f _ _ failure_params (failed, net) (failed', net') o ->
+      @step_failure _ _ failure_params (failed, net) (failed', net') o ->
       key_in_output_trace client id o ->
       in_applied_entries client id net'.
   Proof.
@@ -229,9 +229,9 @@ Section OutputImpliesApplied.
       simpl in *. rewrite_update; eauto.
   Qed.
 
-  Instance TR : TraceRelation step_f :=
+  Instance TR : TraceRelation step_failure :=
     {
-      init := step_f_init;
+      init := step_failure_init;
       T := key_in_output_trace client id ;
       T_dec := key_in_output_trace_dec client id ;
       R := fun s => in_applied_entries client id (snd s)
@@ -241,20 +241,20 @@ Section OutputImpliesApplied.
     unfold in_applied_entries in *.
     break_exists; eexists; intuition eauto.
     destruct s; destruct s'; eapply applied_entries_monotonic; eauto.
-    eauto using refl_trans_1n_n1_trace, step_f_star_raft_intermediate_reachable.
+    eauto using refl_trans_1n_n1_trace, step_failure_star_raft_intermediate_reachable.
   - unfold key_in_output_trace in *. intuition.
     break_exists; intuition.
   - intros.
     destruct s as [failed net].
     destruct s' as [failed' net']. simpl in *.
-    find_apply_lem_hyp step_f_star_raft_intermediate_reachable.
+    find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
     find_apply_lem_hyp in_output_changed; auto.
     eauto using output_implies_in_applied_entries.
   Defined.
 
   Theorem output_implies_applied :
     forall failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       key_in_output_trace client id tr ->
       in_applied_entries client id net.
   Proof.

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -79,7 +79,7 @@ Section RaftMsgRefinement.
     intros.
     induction H10.
     - intuition.
-    -  match goal with [H : step_f _ _ _ |- _ ] => invcs H end.
+    -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
        
        + unfold mgv_refined_net_handlers in *. simpl in *.
          unfold refined_net_handlers in *. simpl in *.
@@ -346,11 +346,11 @@ Section RaftMsgRefinement.
     intros.
     induction H10.
     - intuition.
-    -  match goal with [H : step_f _ _ _ |- _ ] => invcs H end.
+    -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
        + match goal with 
          | [ H : msg_refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (msg_refined_raft_intermediate_reachable x) as Hpost
-                  by (eapply MRRIR_step_f; eauto; eapply SF_deliver; eauto)
+                  by (eapply MRRIR_step_failure; eauto; eapply StepFailure_deliver; eauto)
          
          end.
          unfold mgv_refined_net_handlers in *. simpl in *.
@@ -438,7 +438,7 @@ Section RaftMsgRefinement.
        + match goal with 
          | [ H : msg_refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (msg_refined_raft_intermediate_reachable x) as Hpost
-                  by (eapply MRRIR_step_f; eauto; eapply SF_input; eauto)
+                  by (eapply MRRIR_step_failure; eauto; eapply StepFailure_input; eauto)
          
          end.
          unfold mgv_refined_input_handlers in *. simpl in *.
@@ -539,7 +539,7 @@ Section RaftMsgRefinement.
        + auto.
        + eapply_prop msg_refined_raft_net_invariant_reboot'; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
-         * econstructor. eauto. eapply SF_reboot; eauto.
+         * econstructor. eauto. eapply StepFailure_reboot; eauto.
          * destruct (nwState net h); auto.
     - eapply msg_refined_raft_invariant_handle_input'; eauto.
       eapply MRRIR_handleInput; eauto.
@@ -578,7 +578,7 @@ Section RaftMsgRefinement.
     induction H.
     - constructor.
     - simpl in *.
-      pose proof (RRIR_step_f).
+      pose proof (RRIR_step_failure).
       specialize (H1 failed (mgv_deghost net) failed' (mgv_deghost net') out).
       apply H1; auto.
       apply (@mgv_ghost_simulation_1 _ _ _ ghost_log_params); auto.
@@ -658,9 +658,9 @@ Section RaftMsgRefinement.
     eauto using simulation_1.
   Qed.
 
-  Lemma step_f_star_raft_intermediate_reachable_extend :
+  Lemma step_failure_star_raft_intermediate_reachable_extend :
     forall f net f' net' tr,
-      @step_f_star _ _ raft_msg_refined_failure_params (f, net) (f', net') tr ->
+      @step_failure_star _ _ raft_msg_refined_failure_params (f, net) (f', net') tr ->
       msg_refined_raft_intermediate_reachable net ->
       msg_refined_raft_intermediate_reachable net'.
   Proof.
@@ -669,7 +669,7 @@ Section RaftMsgRefinement.
     induction H using refl_trans_1n_trace_n1_ind; intros; subst.
     - find_inversion. auto.
     - destruct x'. simpl in *.
-      eapply MRRIR_step_f; [|eauto].
+      eapply MRRIR_step_failure; [|eauto].
       eauto.
   Qed.
 
@@ -712,14 +712,14 @@ Section RaftMsgRefinement.
   Proof.
     intros.
     induction H.
-    - exists (mgv_reghost step_m_init). intuition.
+    - exists (mgv_reghost step_async_init). intuition.
         unfold mgv_reghost. constructor.
     - break_exists. break_and.
       apply mgv_ghost_simulation_2 with (gnet := x) in H0; auto.
       repeat (break_exists; intuition).
       subst.
       exists x0. intuition.
-      eapply MRRIR_step_f; eauto.
+      eapply MRRIR_step_failure; eauto.
     - break_exists. break_and.
       subst.
       assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ _ ghost_log_params h (update_elections_data_input h inp (nwState (mgv_deghost x) h), d) l));
@@ -757,8 +757,8 @@ Section RaftMsgRefinement.
         rewrite map_ext with (g := id) in H7; eauto using mgv_deghost_packet_mgv_ghost_packet_partial_inverses.
         rewrite map_id in *. subst.
         unfold mgv_deghost. simpl. auto.
-      + eapply step_f_star_raft_intermediate_reachable_extend with (f := []); eauto using step_f_dup_drop_step.
-        eapply step_f_dup_drop_step.
+      + eapply step_failure_star_raft_intermediate_reachable_extend with (f := []); eauto using step_failure_dup_drop_step.
+        eapply step_failure_dup_drop_step.
         apply dup_drop_reorder; auto.
         auto using packet_eq_dec.
     - break_exists. break_and.
@@ -813,8 +813,8 @@ Section RaftMsgRefinement.
         rewrite map_ext with (g := id) in H7; eauto using mgv_deghost_packet_mgv_ghost_packet_partial_inverses.
         rewrite map_id in *. subst.
         unfold mgv_deghost. simpl. auto.
-      + eapply step_f_star_raft_intermediate_reachable_extend with (f := []); eauto using step_f_dup_drop_step.
-        eapply step_f_dup_drop_step.
+      + eapply step_failure_star_raft_intermediate_reachable_extend with (f := []); eauto using step_failure_dup_drop_step.
+        eapply step_failure_dup_drop_step.
         apply dup_drop_reorder; auto.
         auto using packet_eq_dec.
     - break_exists. break_and.
@@ -854,8 +854,8 @@ Section RaftMsgRefinement.
         rewrite map_ext with (g := id) in H8; eauto using mgv_deghost_packet_mgv_ghost_packet_partial_inverses.
         rewrite map_id in *. subst.
         unfold mgv_deghost. simpl. auto.
-      + eapply step_f_star_raft_intermediate_reachable_extend with (f := []); eauto using step_f_dup_drop_step.
-        eapply step_f_dup_drop_step.
+      + eapply step_failure_star_raft_intermediate_reachable_extend with (f := []); eauto using step_failure_dup_drop_step.
+        eapply step_failure_dup_drop_step.
         apply dup_drop_reorder; auto.
         auto using packet_eq_dec.
     - break_exists. break_and.
@@ -895,8 +895,8 @@ Section RaftMsgRefinement.
         rewrite map_ext with (g := id) in H8; eauto using mgv_deghost_packet_mgv_ghost_packet_partial_inverses.
         rewrite map_id in *. subst.
         unfold mgv_deghost. simpl. auto.
-      + eapply step_f_star_raft_intermediate_reachable_extend with (f := []); eauto using step_f_dup_drop_step.
-        eapply step_f_dup_drop_step.
+      + eapply step_failure_star_raft_intermediate_reachable_extend with (f := []); eauto using step_failure_dup_drop_step.
+        eapply step_failure_dup_drop_step.
         apply dup_drop_reorder; auto.
         auto using packet_eq_dec.
   Qed.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -77,7 +77,7 @@ Section RaftRefinementProof.
     intros.
     induction H10.
     - intuition.
-    -  match goal with [H : step_f _ _ _ |- _ ] => invcs H end.
+    -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
        + unfold refined_net_handlers in *. simpl in *.
          unfold RaftNetHandler, update_elections_data_net in *.
          repeat break_let.
@@ -264,11 +264,11 @@ Section RaftRefinementProof.
     intros.
     induction H10.
     - intuition.
-    -  match goal with [H : step_f _ _ _ |- _ ] => invcs H end.
+    -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
        + match goal with 
          | [ H : refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (refined_raft_intermediate_reachable x) as Hpost
-                  by (eapply RRIR_step_f; eauto; eapply SF_deliver; eauto)
+                  by (eapply RRIR_step_failure; eauto; eapply StepFailure_deliver; eauto)
          
          end.
          unfold refined_net_handlers in *. simpl in *.
@@ -329,7 +329,7 @@ Section RaftRefinementProof.
        + match goal with 
          | [ H : refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (refined_raft_intermediate_reachable x) as Hpost
-               by (eapply RRIR_step_f; eauto; eapply SF_input; eauto)
+               by (eapply RRIR_step_failure; eauto; eapply StepFailure_input; eauto)
          end.
          unfold refined_input_handlers in *. simpl in *.
          unfold RaftInputHandler, update_elections_data_input in *. repeat break_let.
@@ -401,7 +401,7 @@ Section RaftRefinementProof.
        + auto.
        + eapply_prop refined_raft_net_invariant_reboot'; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
-         * econstructor. eauto. eapply SF_reboot; eauto.
+         * econstructor. eauto. eapply StepFailure_reboot; eauto.
          * destruct (nwState net h); auto.
     - eapply refined_raft_invariant_handle_input'; eauto.
       eapply RRIR_handleInput; eauto.
@@ -438,7 +438,7 @@ Section RaftRefinementProof.
     induction H.
     - constructor.
     - simpl in *.
-      pose proof (RIR_step_f).
+      pose proof (RIR_step_failure).
       specialize (H1 failed (deghost net) failed' (deghost net') out).
       apply H1; auto.
       apply ghost_simulation_1; auto.
@@ -516,14 +516,14 @@ Section RaftRefinementProof.
   Proof.
     intros.
     induction H.
-    - exists (reghost step_m_init). intuition.
+    - exists (reghost step_async_init). intuition.
         unfold reghost. constructor.
     - break_exists. break_and.
       apply ghost_simulation_2 with (gnet := x) in H0; auto.
       repeat (break_exists; intuition).
       subst.
       exists x0. intuition.
-      eapply RRIR_step_f; eauto.
+      eapply RRIR_step_failure; eauto.
     - break_exists. break_and.
       subst.
       exists {| nwPackets := map ghost_packet ps' ;

--- a/raft/AppliedEntriesMonotonicInterface.v
+++ b/raft/AppliedEntriesMonotonicInterface.v
@@ -12,13 +12,13 @@ Section AppliedEntriesMonotonicInterface.
       applied_entries_monotonic' :
         forall failed net failed' net' os,
           raft_intermediate_reachable net ->
-          (@step_f _ _ failure_params (failed, net) (failed', net') os) ->
+          (@step_failure _ _ failure_params (failed, net) (failed', net') os) ->
           exists es,
             applied_entries (nwState net') = applied_entries (nwState net) ++ es ;
       applied_entries_monotonic :
         forall e failed net failed' net' os,
           raft_intermediate_reachable net ->
-          (@step_f _ _ failure_params (failed, net) (failed', net') os) ->
+          (@step_failure _ _ failure_params (failed, net) (failed', net') os) ->
           In e (applied_entries (nwState net)) ->
           In e (applied_entries (nwState net'))
     }.

--- a/raft/AppliedImpliesInputInterface.v
+++ b/raft/AppliedImpliesInputInterface.v
@@ -30,7 +30,7 @@ Section AppliedImpliesInputInterface.
     {
       applied_implies_input :
         forall client id failed net tr e,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           eClient e = client ->
           eId e = id ->
           applied_implies_input_state client id (eInput e) net ->

--- a/raft/CausalOrderPreservedInterface.v
+++ b/raft/CausalOrderPreservedInterface.v
@@ -21,7 +21,7 @@ Section CausalOrderPreserved.
     {
       causal_order_preserved :
         forall client id client' id' failed net tr,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           output_before_input client id client' id' tr ->
           entries_ordered client id client' id' net
     }.

--- a/raft/DecompositionWithPostState.v
+++ b/raft/DecompositionWithPostState.v
@@ -182,7 +182,7 @@ Section DecompositionWithPostState.
     intros.
     induction H10.
     - intuition.
-    -  match goal with [H : step_f _ _ _ |- _ ] => invcs H end.
+    -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
        + unfold RaftNetHandler in *. repeat break_let.
          repeat find_inversion.
          assert
@@ -328,7 +328,7 @@ Section DecompositionWithPostState.
        + auto.
        + eapply_prop raft_net_invariant_reboot'; eauto;
          intros; simpl in *; repeat break_if; intuition; subst; intuition eauto.
-         eapply RIR_step_f; eauto.
+         eapply RIR_step_failure; eauto.
          now econstructor; eauto.
     - eapply raft_invariant_handle_input'; eauto using RIR_handleInput.
     - eapply raft_invariant_handle_message'; eauto using RIR_handleMessage.

--- a/raft/InputBeforeOutputInterface.v
+++ b/raft/InputBeforeOutputInterface.v
@@ -17,7 +17,7 @@ Section InputBeforeOutputInterface.
     {
       output_implies_input_before_output :
         forall client id failed net tr,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           key_in_output_trace client id tr ->
           input_before_output client id tr
     }.

--- a/raft/OutputCorrectInterface.v
+++ b/raft/OutputCorrectInterface.v
@@ -11,7 +11,7 @@ Section OutputCorrect.
     {
       output_correct_invariant :
         forall client id out failed net tr,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           in_output_trace client id out tr ->
           output_correct client id out (applied_entries (nwState net))
     }.

--- a/raft/OutputGreatestIdInterface.v
+++ b/raft/OutputGreatestIdInterface.v
@@ -24,7 +24,7 @@ Section OutputGreatestId.
     {
       output_greatest_id :
         forall client id failed net tr,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           key_in_output_trace client id tr ->
           greatest_id_for_client client id net
     }.

--- a/raft/OutputImpliesAppliedInterface.v
+++ b/raft/OutputImpliesAppliedInterface.v
@@ -25,7 +25,7 @@ Section OutputImpliesApplied.
     {
       output_implies_applied :
         forall client id failed net tr,
-          step_f_star step_f_init (failed, net) tr ->
+          step_failure_star step_failure_init (failed, net) tr ->
           key_in_output_trace client id tr ->
           in_applied_entries client id net
     }.

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -745,7 +745,7 @@ Section RaftLinearizableProofs.
 
   Lemma entries_ordered_before_log_to_IR :
     forall k k' net failed tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       In (O k) (import tr) ->
       k <> k' ->
       entries_ordered (fst k) (snd k) (fst k') (snd k') net ->
@@ -828,7 +828,7 @@ Section RaftLinearizableProofs.
 
   Lemma I_before_O :
     forall failed net tr k,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       In (O k) (import tr) ->
       before (I k) (O k) (import tr).
   Proof.
@@ -1107,7 +1107,7 @@ Section RaftLinearizableProofs.
   Theorem raft_linearizable' :
     forall failed net tr,
       input_correct tr ->
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       exists l tr1 st,
         equivalent _ (import tr) l /\
         exported (get_input tr) (get_output tr) l tr1 /\

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -34,11 +34,11 @@ Section RaftMsgRefinementInterface.
   Hint Extern 3 (@FailureParams _ _) => apply raft_msg_refined_failure_params : typeclass_instances.
 
   Inductive msg_refined_raft_intermediate_reachable : network -> Prop :=
-  | MRRIR_init : msg_refined_raft_intermediate_reachable step_m_init
-  | MRRIR_step_f :
+  | MRRIR_init : msg_refined_raft_intermediate_reachable step_async_init
+  | MRRIR_step_failure :
       forall failed net failed' net' out,
         msg_refined_raft_intermediate_reachable net ->
-        step_f (failed, net) (failed', net') out ->
+        step_failure (failed, net) (failed', net') out ->
         msg_refined_raft_intermediate_reachable net'
   | MRRIR_handleInput :
       forall net h inp gd out d l ps' st',
@@ -192,7 +192,7 @@ Section RaftMsgRefinementInterface.
       P net'.
 
   Definition msg_refined_raft_net_invariant_init (P : network -> Prop) :=
-    P step_m_init.
+    P step_async_init.
   
   Definition msg_refined_raft_net_invariant_client_request' (P : network -> Prop) :=
     forall h net st' ps' gd out d l client id c,

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -164,11 +164,11 @@ Section RaftRefinementInterface.
   Hint Extern 4 (@FailureParams _ _) => apply raft_refined_failure_params : typeclass_instances.
 
   Inductive refined_raft_intermediate_reachable : network -> Prop :=
-  | RRIR_init : refined_raft_intermediate_reachable step_m_init
-  | RRIR_step_f :
+  | RRIR_init : refined_raft_intermediate_reachable step_async_init
+  | RRIR_step_failure :
       forall failed net failed' net' out,
         refined_raft_intermediate_reachable net ->
-        step_f (failed, net) (failed', net') out ->
+        step_failure (failed, net) (failed', net') out ->
         refined_raft_intermediate_reachable net'
   | RRIR_handleInput :
       forall net h inp gd out d l ps' st',
@@ -322,7 +322,7 @@ Section RaftRefinementInterface.
       P net'.
 
   Definition refined_raft_net_invariant_init (P : network -> Prop) :=
-    P step_m_init.
+    P step_async_init.
 
   Definition refined_raft_net_invariant_client_request' (P : network -> Prop) :=
     forall h net st' ps' gd out d l client id c,

--- a/raft/StateTraceInvariant.v
+++ b/raft/StateTraceInvariant.v
@@ -11,11 +11,11 @@ Section ST.
   Variable T : list (name * (input + list output)) -> Prop.
 
   Hypothesis T_snoc_inv : forall ev tr, T (tr ++ [ev]) -> T tr.
-  Hypothesis RT_init : T [] -> R step_m_init [].
+  Hypothesis RT_init : T [] -> R step_async_init [].
 
   Definition RT_deliver : Prop :=
     forall net failed tr xs p ys out d l,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T tr ->
       R net tr ->
       nwPackets net = xs ++ p :: ys ->
@@ -28,7 +28,7 @@ Section ST.
 
   Definition RT_input : Prop :=
     forall net failed tr h i out d l,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T (tr ++ [(h, inl i)]) ->
       R net tr ->
       input_handlers h i (nwState net h) = (out, d, l) ->
@@ -40,7 +40,7 @@ Section ST.
 
   Definition RT_drop : Prop :=
     forall net failed tr xs p ys,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T tr ->
       R net tr ->
       nwPackets net = xs ++ p :: ys ->
@@ -51,7 +51,7 @@ Section ST.
 
   Definition RT_dup : Prop :=
     forall net failed tr xs p ys,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T tr ->
       R net tr ->
       nwPackets net = xs ++ p :: ys ->
@@ -62,7 +62,7 @@ Section ST.
 
   Definition RT_reboot : Prop :=
     forall net failed tr h,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T tr ->
       R net tr ->
       R (mkNetwork (nwPackets net) (update name_eq_dec (nwState net) h (reboot (nwState net h))))
@@ -72,18 +72,18 @@ Section ST.
 
   Lemma state_trace_invariant_invariant :
     forall failed net tr,
-      step_f_star step_f_init (failed, net) tr ->
+      step_failure_star step_failure_init (failed, net) tr ->
       T tr ->
       R net tr.
   Proof.
     intros.
     remember (failed, net) as p. generalize dependent failed. revert net.
-    remember step_f_init as init. revert Heqinit. revert H0.
+    remember step_failure_init as init. revert Heqinit. revert H0.
     apply refl_trans_1n_n1_trace in H.
     induction H; intros; subst.
-    - unfold step_f_init in *. find_inversion. auto.
+    - unfold step_failure_init in *. find_inversion. auto.
     - match goal with
-        | [ H : step_f _ _ _ |- _ ] => invc H
+        | [ H : step_failure _ _ _ |- _ ] => invc H
       end.
       + eapply H_RT_deliver with (failed := failed); eauto.
         apply refl_trans_n1_1n_trace; auto.

--- a/systems/Counter.v
+++ b/systems/Counter.v
@@ -219,17 +219,17 @@ Section Counter.
 
   Lemma backup_plus_network_eq_primary :
     forall net tr,
-      step_m_star (params := Counter_MultiParams) step_m_init net tr ->
+      step_async_star (params := Counter_MultiParams) step_async_init net tr ->
       nwState net backup + inc_in_flight_to_backup (nwPackets net) = nwState net primary.
   Proof.
     intros.
-    remember step_m_init as y in *.
+    remember step_async_init as y in *.
     revert Heqy.
     induction H using refl_trans_1n_trace_n1_ind; intros; subst.
     - reflexivity.
     - concludes.
       match goal with
-      | [ H : step_m _ _ _ |- _ ] => invc H
+      | [ H : step_async _ _ _ |- _ ] => invc H
       end; simpl.
       + find_apply_lem_hyp net_handlers_NetHandler.
         find_copy_apply_lem_hyp NetHandler_inc_in_flight_to_backup_preserved.
@@ -258,7 +258,7 @@ Section Counter.
 
   Theorem primary_ge_backup :
     forall net tr,
-      step_m_star (params := Counter_MultiParams) step_m_init net tr ->
+      step_async_star (params := Counter_MultiParams) step_async_init net tr ->
       nwState net backup <= nwState net primary.
   Proof.
     intros.
@@ -387,19 +387,19 @@ Section Counter.
 
   Lemma inputs_eq_outputs_plus_inc_plus_ack :
     forall net tr,
-      step_m_star (params := Counter_MultiParams) step_m_init net tr ->
+      step_async_star (params := Counter_MultiParams) step_async_init net tr ->
       trace_inputs tr = trace_outputs tr +
                         inc_in_flight_to_backup (nwPackets net) +
                         ack_in_flight_to_primary (nwPackets net).
   Proof.
     intros.
-    remember step_m_init as y in *.
+    remember step_async_init as y in *.
     revert Heqy.
     induction H using refl_trans_1n_trace_n1_ind; intros; subst.
     - reflexivity.
     - concludes.
       match goal with
-      | [ H : step_m _ _ _ |- _ ] => invc H
+      | [ H : step_async _ _ _ |- _ ] => invc H
       end; simpl.
       + find_apply_lem_hyp net_handlers_NetHandler.
         repeat find_rewrite.
@@ -429,7 +429,7 @@ Section Counter.
 
   Theorem inputs_ge_outputs :
     forall net tr,
-      step_m_star (params := Counter_MultiParams) step_m_init net tr ->
+      step_async_star (params := Counter_MultiParams) step_async_init net tr ->
       trace_outputs tr <= trace_inputs tr.
   Proof.
     intros.

--- a/systems/LockServ.v
+++ b/systems/LockServ.v
@@ -845,7 +845,7 @@ Section LockServ.
   Defined.
 
   Theorem true_in_reachable_mutual_exclusion :
-    true_in_reachable step_m step_m_init (fun net => mutual_exclusion (nwState net)).
+    true_in_reachable step_async step_async_init (fun net => mutual_exclusion (nwState net)).
   Proof.
     pose proof decomposition_invariant.
     find_apply_lem_hyp inductive_invariant_true_in_reachable.
@@ -898,14 +898,14 @@ Section LockServ.
 
   Lemma cross_relation :
     forall (P : network -> list (name * (input + list output)) -> Prop),
-      P step_m_init [] ->
+      P step_async_init [] ->
       (forall st st' tr ev,
-         step_m_star step_m_init st tr ->
+         step_async_star step_async_init st tr ->
          P st tr ->
-         step_m st st' ev ->
+         step_async st st' ev ->
          P st' (tr ++ ev)) ->
       forall st tr,
-        step_m_star step_m_init st tr ->
+        step_async_star step_async_init st tr ->
         P st tr.
   Proof.
     intros.
@@ -944,7 +944,7 @@ Section LockServ.
 
   Lemma decomposition_reachable_nw_invariant :
     forall st tr p,
-      step_m_star step_m_init st tr ->
+      step_async_star step_async_init st tr ->
       In p (nwPackets st) ->
       network_invariant (nwState st) p.
   Proof.
@@ -969,8 +969,8 @@ Section LockServ.
 
   Lemma reachable_intro :
     forall a tr,
-      step_m_star step_m_init a tr ->
-      reachable step_m step_m_init a.
+      step_async_star step_async_init a tr ->
+      reachable step_async step_async_init a.
   Proof.
     unfold reachable.
     intros. eauto.
@@ -978,7 +978,7 @@ Section LockServ.
 
   Lemma locks_correct_locked_invariant :
     forall st p,
-      reachable step_m step_m_init st ->
+      reachable step_async step_async_init st ->
       In p (nwPackets st) ->
       locks_correct_locked (nwState st) p.
   Proof.
@@ -990,7 +990,7 @@ Section LockServ.
 
   Lemma locks_correct_invariant :
     forall st,
-      reachable step_m step_m_init st ->
+      reachable step_async step_async_init st ->
       locks_correct (nwState st).
   Proof.
     intros.
@@ -1001,7 +1001,7 @@ Section LockServ.
 
   Lemma mutual_exclusion_invariant :
     forall st,
-      reachable step_m step_m_init st ->
+      reachable step_async step_async_init st ->
       mutual_exclusion (nwState st).
   Proof.
     intros.
@@ -1128,7 +1128,7 @@ Section LockServ.
 
   Lemma LockServ_mutual_exclusion_trace :
     forall st tr,
-      step_m_star step_m_init st tr ->
+      step_async_star step_async_init st tr ->
       trace_mutual_exclusion tr /\
       (forall n, last_holder tr = Some n -> held (nwState st (Client n)) = true) /\
       (forall n, held (nwState st (Client n)) = true -> last_holder tr = Some n).
@@ -1139,7 +1139,7 @@ Section LockServ.
       + unfold last_holder in *. simpl in *. discriminate.
       + unfold last_holder in *. simpl in *. discriminate.
     - match goal with
-        | [ H : step_m _ _ _ |- _ ] => invcs H
+        | [ H : step_async _ _ _ |- _ ] => invcs H
       end; monad_unfold; repeat break_let; repeat find_inversion.
       + unfold NetHandler in *. break_match.
         * find_apply_lem_hyp ClientNetHandler_cases.

--- a/systems/LockServSeqNum.v
+++ b/systems/LockServSeqNum.v
@@ -18,7 +18,7 @@ Section LockServSeqNum.
 
   Theorem transformed_correctness :
     forall (net : transformed_network) tr,
-      step_d_star (params := transformed_multi_params) step_m_init net tr ->
+      step_dup_star (params := transformed_multi_params) step_async_init net tr ->
       @mutual_exclusion num_Clients (nwState (revertNetwork net)).
   Proof.
     intros.

--- a/systems/PrimaryBackup.v
+++ b/systems/PrimaryBackup.v
@@ -663,7 +663,7 @@ Section PrimaryBackup.
 
   Lemma correspond_reachable :
     forall net tr_m,
-      step_m_star step_m_init net tr_m ->
+      step_async_star step_async_init net tr_m ->
       forall st tr_1,
         step_1_star init st tr_1 ->
         inputs_1 tr_1 = inputs_m tr_m ->
@@ -726,7 +726,7 @@ Section PrimaryBackup.
 
   Lemma correspond_inductive :
     forall net net' tr_m',
-      step_m net net' tr_m' ->
+      step_async net net' tr_m' ->
       forall st st' tr_m tr_1 tr_1',
         correspond st (nwState net) tr_1 tr_m ->
         step_1_star st st' tr_1' ->
@@ -788,9 +788,9 @@ Section PrimaryBackup.
       eapply correspond_preserved_snoc; eauto; rewrite update_eq by auto; repeat find_rewrite; auto.
   Qed.
 
-  Lemma step_m_outputs_m :
+  Lemma step_async_outputs_m :
     forall net net' tr,
-      step_m net net' tr ->
+      step_async net net' tr ->
       (inputs_m tr = [] /\ (outputs_m tr = [] /\ nwState net Primary = nwState net' Primary)) \/
       (inputs_m tr = [] /\ exists os, outputs_m tr = [os]) \/
       (exists i, inputs_m tr = [i]).
@@ -853,7 +853,7 @@ Section PrimaryBackup.
 
   Lemma network_invariant_inductive :
     forall net net' tr,
-      step_m net net' tr ->
+      step_async net net' tr ->
       network_invariant net ->
       network_invariant net'.
   Proof.
@@ -868,7 +868,7 @@ Section PrimaryBackup.
   Qed.
 
   Lemma network_invariant_init :
-    network_invariant step_m_init.
+    network_invariant step_async_init.
   Proof.
     unfold network_invariant. simpl. auto.
   Qed.
@@ -907,7 +907,7 @@ Section PrimaryBackup.
 
   Lemma inductive_simulation :
     forall net net' tr,
-      step_m net net' tr ->
+      step_async net net' tr ->
       step_1_star (revert_state net) (revert_state net') (revert_trace tr).
   Proof.
     intros.
@@ -949,14 +949,14 @@ Section PrimaryBackup.
 
   Lemma simulation :
     forall net tr,
-      step_m_star step_m_init net tr ->
+      step_async_star step_async_init net tr ->
       step_1_star init (revert_state net) (revert_trace tr).
   Proof.
     intros.
     apply refl_trans_1n_n1_trace in H.
     prep_induction H.
     induction H; intros; subst.
-    - unfold step_m_init, revert_state. constructor.
+    - unfold step_async_init, revert_state. constructor.
     - repeat concludes. rewrite revert_trace_app.
       unfold step_1_star.
       find_apply_lem_hyp inductive_simulation.
@@ -971,7 +971,7 @@ Section PrimaryBackup.
          step_1_star init st tr ->
          P tr) ->
       (forall net tr,
-         step_m_star step_m_init net tr ->
+         step_async_star step_async_init net tr ->
          P (revert_trace tr)).
   Proof.
     intros.
@@ -1122,7 +1122,7 @@ Section PrimaryBackup.
 
   Theorem pbj_NOABT :
     forall net tr,
-      step_m_star (params:=PB_multi_params) step_m_init net tr ->
+      step_async_star (params:=PB_multi_params) step_async_init net tr ->
       no_output_at_backup_trace tr.
   Proof.
     intros.
@@ -1235,7 +1235,7 @@ Section PrimaryBackup.
 
   Theorem pbj_0_or_1 :
     forall net tr,
-      step_m_star (params:=PB_multi_params) step_m_init net tr ->
+      step_async_star (params:=PB_multi_params) step_async_init net tr ->
       zero_or_one_outputs_per_step_trace tr.
   Proof.
     intros.
@@ -1259,7 +1259,7 @@ Section PrimaryBackup.
 
   Lemma inputs_1_m_revert :
     forall net tr,
-      step_m_star (params := PB_multi_params) step_m_init net tr ->
+      step_async_star (params := PB_multi_params) step_async_init net tr ->
       inputs_m tr = inputs_1 (revert_trace tr) ++ queue (nwState net Primary).
   Proof.
     intros.

--- a/systems/SeqNumCorrect.v
+++ b/systems/SeqNumCorrect.v
@@ -154,12 +154,12 @@ Section SeqNumCorrect.
        tmNum (pBody p) < (tdNum ((nwState net) (pSrc p)))).
 
   Lemma reachable_sane :
-    true_in_reachable step_d step_m_init sequence_sane.
+    true_in_reachable step_dup step_async_init sequence_sane.
   Proof.
     apply inductive_invariant_true_in_reachable. unfold inductive_invariant, inductive.
     unfold sequence_sane. simpl in *. intuition.
     match goal with
-      | [ H : step_d _ _ _ |- _ ] =>
+      | [ H : step_dup _ _ _ |- _ ] =>
         invcs H
     end; try find_inversion.
     - (* deliver case *)
@@ -199,13 +199,13 @@ Section SeqNumCorrect.
       n < (tdNum (nwState net h)).
 
   Lemma reachable_seen :
-    true_in_reachable step_d step_m_init sequence_seen.
+    true_in_reachable step_dup step_async_init sequence_seen.
   Proof.
     apply true_in_reachable_reqs; 
     unfold sequence_seen; simpl in *; intuition.
     find_apply_lem_hyp reachable_sane.
     unfold sequence_sane in *.
-    match goal with H : step_d _ _ _ |- _ => invcs H end.
+    match goal with H : step_dup _ _ _ |- _ => invcs H end.
     - (* step case *)
       unfold seq_num_net_handlers in *.
       repeat (break_match; try find_inversion; simpl in *; eauto);
@@ -236,7 +236,7 @@ Section SeqNumCorrect.
       p = p'.
 
   Theorem reachable_equality :
-    true_in_reachable step_d step_m_init sequence_equality.
+    true_in_reachable step_dup step_async_init sequence_equality.
   Proof.
     apply true_in_reachable_reqs; 
     unfold sequence_equality; simpl in *; intuition.
@@ -246,7 +246,7 @@ Section SeqNumCorrect.
     end.
     unfold sequence_sane, sequence_equality in *.
     intros.
-    match goal with H : step_d _ _ _ |- _ => invcs H end; simpl in *; find_inversion.
+    match goal with H : step_dup _ _ _ |- _ => invcs H end; simpl in *; find_inversion.
     - unfold seq_num_net_handlers in *.
       repeat do_in_app.
       repeat find_rewrite.
@@ -512,9 +512,9 @@ Section SeqNumCorrect.
   
   Lemma reachable_revert_step :
     forall st st' out,
-      reachable step_d step_m_init st ->
-      step_d st st' out ->
-      (exists out, step_m (revertNetwork st) (revertNetwork st') out)
+      reachable step_dup step_async_init st ->
+      step_dup st st' out ->
+      (exists out, step_async (revertNetwork st) (revertNetwork st') out)
       \/ revertNetwork st = revertNetwork st'.
   Proof.
     intros.
@@ -522,7 +522,7 @@ Section SeqNumCorrect.
     find_copy_apply_lem_hyp reachable_seen.
     find_copy_apply_lem_hyp reachable_equality.
     break_exists.
-    match goal with H : step_d _ _ _ |- _ => invcs H end.
+    match goal with H : step_dup _ _ _ |- _ => invcs H end.
     - unfold seq_num_net_handlers in *. break_if.
       + right. find_inversion. simpl in *.
         unfold revertNetwork. simpl in *. intuition.
@@ -556,9 +556,9 @@ Section SeqNumCorrect.
   Qed.
 
   Theorem reachable_revert :
-    true_in_reachable step_d step_m_init
+    true_in_reachable step_dup step_async_init
                       (fun st =>
-                         reachable step_m step_m_init (revertNetwork st)).
+                         reachable step_async step_async_init (revertNetwork st)).
   Proof.
     apply true_in_reachable_reqs.
     - unfold revertNetwork. simpl.
@@ -576,8 +576,8 @@ Section SeqNumCorrect.
 
   Theorem true_in_reachable_transform :
     forall P,
-      true_in_reachable step_m step_m_init P ->
-      true_in_reachable step_d step_m_init (fun net => P (revertNetwork net)).
+      true_in_reachable step_async step_async_init P ->
+      true_in_reachable step_dup step_async_init (fun net => P (revertNetwork net)).
   Proof.
     intros. find_apply_lem_hyp true_in_reachable_elim. intuition.
     apply true_in_reachable_reqs; eauto.

--- a/systems/VarDPrimaryBackup.v
+++ b/systems/VarDPrimaryBackup.v
@@ -12,7 +12,7 @@ Instance vard_pbj_params : PrimaryBackupParams vard_base_params :=
 
 Theorem lifting_applied :
   forall (net : @network _ PB_multi_params) tr,
-    step_m_star step_m_init net tr ->
+    step_async_star step_async_init net tr ->
     trace_correct (revert_trace (base_params := vard_base_params) tr).
 Proof.
   apply transformer.
@@ -23,7 +23,7 @@ Eval compute in revert_trace [(Primary, inl (Request (Put "james" "awesome")))].
 
 Example revert_trace_eg :
   forall net tr o,
-    step_m_star (params := PB_multi_params) step_m_init net tr ->
+    step_async_star (params := PB_multi_params) step_async_init net tr ->
     inputs_m tr = [Put "james" "awesome"] ->
     outputs_m tr = [o] ->
     o = Response "james" (Some "awesome") None.
@@ -51,7 +51,7 @@ Qed.
 
 Example get_set_eg1 :
   forall tr (net : @network _ PB_multi_params) a b,
-    step_m_star step_m_init net tr ->
+    step_async_star step_async_init net tr ->
     inputs_m tr = [Put "james" "awesome"; Get "james"] ->
     outputs_m tr = [a; b] ->
     outputs_m tr = [Response "james" (Some "awesome") None;


### PR DESCRIPTION
To allow adding more step relations (network semantics) without risk of name clashes and confusion, I here introduce a more verbose naming schema for type names and case names. Style documentation has been updated accordingly.