### PR TITLE
pulled out and improved extraction-related definitions from VarDRaft

### DIFF
--- a/extraction/vard/coq/ExtractVarDRaft.v
+++ b/extraction/vard/coq/ExtractVarDRaft.v
@@ -1,7 +1,4 @@
 Require Import Verdi.
-Require Import NPeano.
-Require Import PeanoNat.
-Require Import StructTact.Fin.
 Require Import VarD.
 Require Import VarDRaft.
 
@@ -9,24 +6,11 @@ Require Import ExtrOcamlBasic.
 Require Import ExtrOcamlNatInt.
 Require Import ExtrOcamlString.
 
-Extract Inlined Constant Nat.max => "Pervasives.max".
-Extract Inlined Constant Nat.min => "Pervasives.min".
+Require Import ExtrOcamlBasicExt.
+Require Import ExtrOcamlNatIntExt.
 
-Extract Inlined Constant length => "List.length".
-Extract Inlined Constant negb => "not".
-Extract Inlined Constant app => "List.append".
-Extract Inlined Constant map => "List.map".
-Extract Inlined Constant rev => "List.rev".
-Extract Inlined Constant filter => "List.filter".
-Extract Inlined Constant fold_left => "(fun a b c -> List.fold_left a c b)".
-Extract Inlined Constant in_dec => "(fun h -> List.mem)".
-Extract Inlined Constant leb => "(<=)".
-Extract Inlined Constant Nat.ltb => "(<)".
-Extract Inlined Constant Nat.pred => "(fun n -> if n <= 0 then 0 else n - 1)".
-
-Extract Inlined Constant fin => int.
-
-Extract Inlined Constant fin_eq_dec => "(fun _ -> (=))".
-Extract Inlined Constant all_fin => "(fun n -> (Obj.magic (seq 1 n)))".
+Require Import ExtrOcamlBool.
+Require Import ExtrOcamlList.
+Require Import ExtrOcamlFin.
 
 Extraction "extraction/vard/coq/VarDRaft.ml" seq vard_raft_base_params vard_raft_multi_params vard_raft_failure_params.

--- a/lib/ExtrOcamlBasicExt.v
+++ b/lib/ExtrOcamlBasicExt.v
@@ -1,0 +1,2 @@
+Extract Inlined Constant fst => "fst".
+Extract Inlined Constant snd => "snd".

--- a/lib/ExtrOcamlBool.v
+++ b/lib/ExtrOcamlBool.v
@@ -1,0 +1,6 @@
+Require Import Bool.
+
+Extract Inlined Constant negb => "not".
+
+Extract Inlined Constant leb => "(<=)".
+Extract Inlined Constant bool_dec => "(=)".

--- a/lib/ExtrOcamlFin.v
+++ b/lib/ExtrOcamlFin.v
@@ -1,0 +1,12 @@
+Require Import StructTact.Fin.
+
+Extract Inlined Constant fin => int.
+
+Extract Inlined Constant fin_eq_dec => "(fun _ -> (=))".
+
+Extract Inlined Constant all_fin => "(fun n -> (Obj.magic (seq 1 n)))".
+
+Extract Inlined Constant fin_to_nat => "(fun _ n -> n)".
+
+Extract Inlined Constant fin_compare => "(fun _ n m -> if n = m then EQ else if n < m then LT else GT)".
+Extract Inlined Constant fin_comparison => "(fun _ n m -> if n = m then Eq else if n < m then Lt else Gt)".

--- a/lib/ExtrOcamlList.v
+++ b/lib/ExtrOcamlList.v
@@ -1,0 +1,11 @@
+Require Import List.
+
+Extract Inlined Constant length => "List.length".
+Extract Inlined Constant app => "List.append".
+
+Extract Inlined Constant map => "List.map".
+Extract Inlined Constant rev => "List.rev".
+Extract Inlined Constant filter => "List.filter".
+Extract Inlined Constant fold_left => "(fun a b c -> List.fold_left a c b)".
+
+Extract Inlined Constant in_dec => "(fun h -> List.mem)".

--- a/lib/ExtrOcamlNatIntExt.v
+++ b/lib/ExtrOcamlNatIntExt.v
@@ -1,0 +1,6 @@
+Require Import PeanoNat.
+
+Extract Inlined Constant Nat.max => "Pervasives.max".
+Extract Inlined Constant Nat.min => "Pervasives.min".
+
+Extract Inlined Constant Nat.ltb => "(<)".


### PR DESCRIPTION
Extraction of `VarDRaft` inlines many constants. Here, I pull out these constant inline definitions and put them in files under `lib/` to enable reuse. I also added some obvious inlines (for `fst`, `snd` and `bool_dec`) that were missing, and all inlines for all relevant `fin` functions.

The diff I got for `VarDRaft.ml` before and after the refactored inlining (`diff VarDRaft.ml VarDRaft_orig.ml`) is as follows:
```
2a3,9
> (** val fst : ('a1 * 'a2) -> 'a1 **)
> 
> let fst = function
> | (x, _) -> x
> 
> 
> 
8a16,20
> (** val bool_dec : bool -> bool -> bool **)
> 
> let bool_dec b1 b2 =
>   if b1 then if b2 then true else false else if b2 then false else true
> 
891c903
<        if term_eq_dec x0 t0 then (=) x1 b0 else false
---
>        if term_eq_dec x0 t0 then bool_dec x1 b0 else false
916c928
<             then (=) x2 b0
---
>             then bool_dec x2 b0
```