### PR TITLE
add reference to Verdi Raft in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Files
       primary-backup replication
       - `VarDPB.v`, the primary-backup transformer applied to the
         key-value store
+
+Projects using Verdi
+--------------------
+
+- [`Verdi Raft`](https://github.com/uwplse/verdi-raft): a verified implementation of the Raft distributed consensus protocol


### PR DESCRIPTION
Just adding a link to the Verdi Raft github repo (should probably be to separate website at some point).