### PR TITLE
extract all_fin to 0..n-1 instead of 1..n, to match fin_to_nat

### DIFF
--- a/extraction/coq/ExtrOcamlFin.v
+++ b/extraction/coq/ExtrOcamlFin.v
@@ -4,7 +4,7 @@ Extract Inlined Constant fin => int.
 
 Extract Inlined Constant fin_eq_dec => "(fun _ -> (=))".
 
-Extract Inlined Constant all_fin => "(fun n -> (Obj.magic (seq 1 n)))".
+Extract Inlined Constant all_fin => "(fun n -> (Obj.magic (seq 0 n)))".
 
 Extract Inlined Constant fin_to_nat => "(fun _ n -> n)".
 


### PR DESCRIPTION
Verdi projects may rely on both `all_fin` and `fin_to_nat`, which are currently not consistent when extracted - `all_fin` starts at 1 and `fin_to_nat` can return 0. This makes them consistent. Various scripts and documentation should be updated in Verdi Raft after this PR is merged.