### PR TITLE
put type classes in Prop sort when possible

### DIFF
--- a/core/PartialExtendedMapSimulations.v
+++ b/core/PartialExtendedMapSimulations.v
@@ -46,7 +46,7 @@ Class MultiParamsPartialExtendedMapCongruency
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (N : MultiParamsNameTotalMap P0 P1)
   (P : MultiParamsMsgPartialMap P0 P1)
-  (P : MultiParamsPartialExtendedMap P0 P1) :=
+  (P : MultiParamsPartialExtendedMap P0 P1) : Prop :=
   {
     pt_ext_init_handlers_eq : forall n,
       pt_ext_map_data (init_handlers n) n = init_handlers (tot_map_name n) ;
@@ -72,7 +72,7 @@ Class FailureParamsPartialExtendedMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (F0 : FailureParams P0) (F1 : FailureParams P1)
-  (P : MultiParamsPartialExtendedMap P0 P1) :=
+  (P : MultiParamsPartialExtendedMap P0 P1) : Prop :=
   {
     pt_ext_reboot_eq : forall d me,
       pt_ext_map_data (reboot d) me = reboot (pt_ext_map_data d me)

--- a/core/PartialMapExecutionSimulations.v
+++ b/core/PartialMapExecutionSimulations.v
@@ -23,7 +23,7 @@ Class LabeledMultiParamsPartialMapCongruency
   (B : BaseParamsPartialMap B0 B1) 
   (N : MultiParamsNameTotalMap (@unlabeled_multi_params _ P0) (@unlabeled_multi_params _ P1))
   (P : MultiParamsMsgPartialMap (@unlabeled_multi_params _ P0) (@unlabeled_multi_params _ P1))
-  (L : LabeledMultiParamsLabelTotalMap P0 P1) :=
+  (L : LabeledMultiParamsLabelTotalMap P0 P1) : Prop :=
   {
     pt_lb_label_silent_fst_snd : tot_map_label label_silent = label_silent ;
     pt_lb_net_handlers_some : forall me src m st m' out st' ps lb,

--- a/core/PartialMapSimulations.v
+++ b/core/PartialMapSimulations.v
@@ -66,7 +66,7 @@ Class MultiParamsPartialMapCongruency
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (B : BaseParamsPartialMap B0 B1) 
   (N : MultiParamsNameTotalMap P0 P1)
-  (P : MultiParamsMsgPartialMap P0 P1) :=
+  (P : MultiParamsMsgPartialMap P0 P1) : Prop :=
   {
     pt_init_handlers_eq : forall n, 
       pt_map_data (init_handlers n) = init_handlers (tot_map_name n) ;
@@ -94,7 +94,7 @@ Class FailureParamsPartialMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (F0 : FailureParams P0) (F1 : FailureParams P1)
-  (B : BaseParamsPartialMap B0 B1) :=
+  (B : BaseParamsPartialMap B0 B1) : Prop :=
   {
     pt_reboot_eq : forall d, pt_map_data (reboot d) = reboot (pt_map_data d)
   }.
@@ -103,7 +103,7 @@ Class FailMsgParamsPartialMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (F0 : FailMsgParams P0) (F1 : FailMsgParams P1)
-  (P : MultiParamsMsgPartialMap P0 P1) :=
+  (P : MultiParamsMsgPartialMap P0 P1) : Prop :=
   {
     pt_fail_msg_fst_snd : pt_map_msg msg_fail = Some msg_fail
   }.
@@ -112,7 +112,7 @@ Class NewMsgParamsPartialMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (N0 : NewMsgParams P0) (N1 : NewMsgParams P1)
-  (P : MultiParamsMsgPartialMap P0 P1) :=
+  (P : MultiParamsMsgPartialMap P0 P1) : Prop :=
   {
     pt_new_msg_fst_snd : pt_map_msg msg_new = Some msg_new
   }.

--- a/core/SingleSimulations.v
+++ b/core/SingleSimulations.v
@@ -17,7 +17,7 @@ Class MultiSingleParamsTotalMap
 Class MultiSingleParamsTotalMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : SingleParams B1)
-  (M : MultiSingleParamsTotalMap P0 B1) (me : name) :=
+  (M : MultiSingleParamsTotalMap P0 B1) (me : name) : Prop :=
   {
     tot_s_init_handlers_eq : tot_s_map_data (init_handlers me) = init_handler ;
     tot_s_input_handlers_eq : forall inp st out st' ps out' st'',

--- a/core/TotalMapExecutionSimulations.v
+++ b/core/TotalMapExecutionSimulations.v
@@ -43,7 +43,7 @@ Class LabeledMultiParamsTotalMapCongruency
   (B : BaseParamsTotalMap B0 B1) 
   (N : MultiParamsNameTotalMap (@unlabeled_multi_params _ P0) (@unlabeled_multi_params _ P1))
   (P : MultiParamsMsgTotalMap (@unlabeled_multi_params _ P0) (@unlabeled_multi_params _ P1))
-  (L : LabeledMultiParamsLabelTotalMap P0 P1) :=
+  (L : LabeledMultiParamsLabelTotalMap P0 P1) : Prop :=
   {
     tot_lb_net_handlers_eq : forall me src m st out st' ps lb, 
       lb_net_handlers (tot_map_name me) (tot_map_name src) (tot_map_msg m) (tot_map_data st) = (lb, out, st', ps)  ->

--- a/core/TotalMapSimulations.v
+++ b/core/TotalMapSimulations.v
@@ -26,7 +26,7 @@ Class MultiParamsNameTotalMap
     tot_map_name_inv : @name B1 P1 -> @name B0 P0
   }.
 
-Class MultiParamsNameTotalMapBijective `(M : MultiParamsNameTotalMap) :=
+Class MultiParamsNameTotalMapBijective `(M : MultiParamsNameTotalMap) : Prop :=
   {
     tot_map_name_inv_inverse : forall n, tot_map_name_inv (tot_map_name n) = n ;
     tot_map_name_inverse_inv : forall n, tot_map_name (tot_map_name_inv n) = n ;
@@ -67,7 +67,7 @@ Class MultiParamsTotalMapCongruency
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (B : BaseParamsTotalMap B0 B1)
   (N : MultiParamsNameTotalMap P0 P1)
-  (P : MultiParamsMsgTotalMap P0 P1) :=
+  (P : MultiParamsMsgTotalMap P0 P1) : Prop :=
   {
     tot_init_handlers_eq : forall n,
       tot_map_data (init_handlers n) = init_handlers (tot_map_name n) ;
@@ -83,7 +83,7 @@ Class FailureParamsTotalMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (F0 : FailureParams P0) (F1 : FailureParams P1)
-  (B : BaseParamsTotalMap B0 B1) :=
+  (B : BaseParamsTotalMap B0 B1) : Prop :=
   {
     tot_reboot_eq : forall d, tot_map_data (reboot d) = reboot (tot_map_data d)
   }.
@@ -92,7 +92,7 @@ Class NameOverlayParamsTotalMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (O0 : NameOverlayParams P0) (O1 : NameOverlayParams P1)
-  (N : MultiParamsNameTotalMap P0 P1) :=
+  (N : MultiParamsNameTotalMap P0 P1) : Prop :=
   {
     tot_adjacent_to_fst_snd : forall n n',
       adjacent_to n n' <-> adjacent_to (tot_map_name n) (tot_map_name n')
@@ -102,7 +102,7 @@ Class FailMsgParamsTotalMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (F0 : FailMsgParams P0) (F1 : FailMsgParams P1)
-  (P : MultiParamsMsgTotalMap P0 P1) :=
+  (P : MultiParamsMsgTotalMap P0 P1) : Prop :=
   {
     tot_fail_msg_fst_snd : msg_fail = tot_map_msg msg_fail
   }.
@@ -111,7 +111,7 @@ Class NewMsgParamsTotalMapCongruency
   (B0 : BaseParams) (B1 : BaseParams)
   (P0 : MultiParams B0) (P1 : MultiParams B1)
   (N0 : NewMsgParams P0) (N1 : NewMsgParams P1)
-  (P : MultiParamsMsgTotalMap P0 P1) :=
+  (P : MultiParamsMsgTotalMap P0 P1) : Prop :=
   {
     tot_new_msg_fst_snd : msg_new = tot_map_msg msg_new
   }.


### PR DESCRIPTION
May prevent extracting crap into OCaml modules.