### PR TITLE
use specific Coq and ssreflect versions for Travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -3,7 +3,7 @@ set -ev
 opam init --yes --no-setup
 eval $(opam config env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq coq-mathcomp-ssreflect --yes --verbose
+opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION --yes --verbose
 
 pushd ..
   git clone -b $STRUCTTACT_BRANCH 'http://github.com/uwplse/StructTact'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
       - opam
 env:
   global:
+    - COQ_VERSION=8.5.3
+    - SSREFLECT_VERSION=1.6
     - VERDI_RAFT_BRANCH=master
     - STRUCTTACT_BRANCH=master
   matrix:


### PR DESCRIPTION
Make Coq package versions configurable and freeze to latest versions to prevent premature upgrading in the future.