### PR TITLE
Refactor unordered shim to omit request_id

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -3,7 +3,7 @@ set -ev
 opam init --yes --no-setup
 eval $(opam config env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION --yes --verbose
+opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION uuidm.0.9.6 --yes --verbose
 
 pushd ..
   git clone -b $STRUCTTACT_BRANCH 'http://github.com/uwplse/StructTact'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=master
+    - VERDI_RAFT_BRANCH=adapt-vard-arrangement
     - STRUCTTACT_BRANCH=master
   matrix:
     - DOWNSTREAM=none


### PR DESCRIPTION
The current unordered shim needlessly assumes both a client id and a request id for inputs and outputs. This PR removes that constraints and allows arrangements to define only a client id type and a generator of terms of that type (most easily via UUID).

On merge, commit 925354a should not be included, since it only specifies to build against a particular Verdi Raft branch.