### PR TITLE
Dynamic ordered shim

### DIFF
--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -174,10 +174,8 @@ module Shim (A: ARRANGEMENT) = struct
     print_newline ();
     let write_fd = socket PF_INET SOCK_STREAM 0 in
     connect write_fd node_addr;
-    printf "sending me\n";
     send_chunk write_fd (A.serializeName env.me) (close_and_fail_node env write_fd);
     let (ip, port) = sock_of_name env env.me in
-    printf "sending sock\n";
     send_chunk write_fd (sprintf "%s:%d" ip port) (close_and_fail_node env write_fd);
     begin
       match A.newMsg with

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -84,6 +84,7 @@ module Shim (A: ARRANGEMENT) = struct
 
   (* Initialize environment, and start server. *)
   let setup (cfg : cfg) : (env * A.state) =
+    Random.self_init ();
     let env =
       { cluster = Hashtbl.create (List.length cfg.cluster)
       ; port = cfg.port

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -183,9 +183,10 @@ module Shim (A: ARRANGEMENT) = struct
     let (ip, port) = sock_of_name env env.me in
     printf "sending sock\n";
     send_chunk write_fd (sprintf "%s:%d" ip port) (close_and_fail_node env write_fd);
-    begin match A.newMsg with
-          | Some m -> send_on_fd write_fd m (close_and_fail_node env write_fd)
-          | None -> ()
+    begin
+      match A.newMsg with
+      | Some m -> send_on_fd write_fd m (close_and_fail_node env write_fd)
+      | None -> ()
     end;
     print_endline "...connected!";
     Hashtbl.replace env.node_write_fds node_name write_fd;
@@ -210,7 +211,8 @@ module Shim (A: ARRANGEMENT) = struct
     let (c, out) = A.serializeOutput o in
     let fd =
       try denote_client env c
-      with Not_found -> failwith "output: failed to find destination" in
+      with Not_found -> failwith "output: failed to find destination"
+    in
     send_chunk fd out (close_and_fail_client env fd)
 
   let respond env ((os, s), ps) =
@@ -231,9 +233,10 @@ module Shim (A: ARRANGEMENT) = struct
 
   let recv_step (env : env) (fd : file_descr) (state : A.state) : A.state =
     let buf = receive_chunk env fd (close_and_fail_node env fd) in
-    let src = try undenote_node env fd
-              with Not_found ->
-                failwith ("recv_step: failed to find source for message (it has probably been marked failed)") in
+    let src =
+      try undenote_node env fd
+      with Not_found -> failwith "recv_step: failed to find source for message (it has probably been marked failed)"
+    in
     let msg = A.deserializeMsg buf in
     deliver_msg env state src msg
 

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -109,11 +109,6 @@ module Shim (A: ARRANGEMENT) = struct
     listen env.input_fd 8;
     (env, initial_state)
 
-  let string_of_sockaddr (saddr : sockaddr) : string =
-    match saddr with
-    | ADDR_UNIX path -> (sprintf "unix://%s" path)
-    | ADDR_INET (addr, port) -> (sprintf "%s:%d" (string_of_inet_addr addr) port)
-
   let close_node_conn env fd =
     let n = undenote_node env fd in
     Hashtbl.remove env.node_read_fds fd;

--- a/extraction/ocaml/Shim.ml
+++ b/extraction/ocaml/Shim.ml
@@ -1,5 +1,6 @@
 open Printf
 open Unix
+open Util
 
 let _CLOG = "clog.bin"
 let _SNAP = "snapshot.bin"
@@ -143,11 +144,6 @@ module Shim (A: ARRANGEMENT) = struct
     bind env.isock (ADDR_INET (inet_addr_any, cfg.port));
     listen env.isock 8;
     (env, initial_state)
-
-  let string_of_sockaddr (saddr : sockaddr) : string =
-    match saddr with
-    | ADDR_UNIX path -> (sprintf "unix://%s" path)
-    | ADDR_INET (addr, port) -> (sprintf "%s:%d" (string_of_inet_addr addr) port)
 
   let disconnect env fd reason =
     let c = undenote_client env fd in

--- a/extraction/ocaml/Util.ml
+++ b/extraction/ocaml/Util.ml
@@ -23,3 +23,8 @@ let string_of_char_list l =
     | [] -> res
     | c :: l -> res.[i] <- c; imp (i + 1) l in
   imp 0 l
+
+let string_of_sockaddr (saddr : Unix.sockaddr) : string =
+  match saddr with
+  | Unix.ADDR_UNIX path -> (Printf.sprintf "unix://%s" path)
+  | Unix.ADDR_INET (addr, port) -> (Printf.sprintf "%s:%d" (Unix.string_of_inet_addr addr) port)


### PR DESCRIPTION
Make the ordered shim's cluster into a (mutable) hash table to enable dynamic addition of neighboring nodes. Put `string_of_sock_addr` function in `Util` module to share it between the unordered and ordered shims.