### PR TITLE
Fair shims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=refactored-shim-compatible
+    - VERDI_RAFT_BRANCH=compatible-unordered-shim
     - STRUCTTACT_BRANCH=master
   matrix:
     - DOWNSTREAM=none

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=master
+    - VERDI_RAFT_BRANCH=refactored-shim-compatible
     - STRUCTTACT_BRANCH=master
   matrix:
     - DOWNSTREAM=none

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=compatible-unordered-shim
+    - VERDI_RAFT_BRANCH=master
     - STRUCTTACT_BRANCH=master
   matrix:
     - DOWNSTREAM=none

--- a/extraction/ocaml/Daemon.ml
+++ b/extraction/ocaml/Daemon.ml
@@ -1,51 +1,53 @@
-type task = 
+type ('env, 'state) task  = 
   {
     fd : Unix.file_descr ;
     mutable select_on : bool ;
     mutable wake_time : float option ;
-    mutable process_read : task -> bool * task list ;
-    mutable process_wake : task -> bool * task list ;
-    finalize : task -> unit ;
+    mutable process_read : ('env, 'state) task -> 'env -> 'state -> bool * ('env, 'state) task list * 'state ;
+    mutable process_wake : ('env, 'state) task -> 'env -> 'state -> bool * ('env, 'state) task list * 'state ;
+    finalize : ('env, 'state) task -> 'env -> 'state -> 'state ;
   }
 
-let handle_result hts task finish ts =
-  if finish then (Hashtbl.remove hts task.fd; task.finalize task);
-  List.iter (fun t -> Hashtbl.add hts t.fd t) ts
+let process f t hts env state =
+  let state = ref state in
+  let (finished, ts, state') = f t env !state in
+  state := state';
+  if finished then begin 
+    Hashtbl.remove hts t.fd; 
+    state := t.finalize t env !state 
+  end;
+  List.iter (fun t' -> Hashtbl.add hts t'.fd t') ts;
+  !state
 
-let rec eloop default_timeout hts =
+let rec eloop default_timeout hts env state =
+  let state = ref state in
   let start_time = Unix.gettimeofday () in
   let (select_fds, min_timeout) = 
-    Hashtbl.fold 
+    Hashtbl.fold
       (fun fd t (fds, timeout) ->
 	let fds' = if t.select_on then fd :: fds else fds in
-	let timeout' = 
-	  match t.wake_time with 
-	  | None -> timeout 
-	  | Some wake_time -> min timeout wake_time in
-        (fds', timeout'))
+	let timeout' =
+	  match t.wake_time with
+	  | None -> timeout
+	  | Some wake_time -> min timeout wake_time 
+	in (fds', timeout'))
       hts ([], default_timeout) in
   let (ready_fds, _, _) = Unix.select select_fds [] [] min_timeout in
-  List.iter 
+  List.iter
     (fun fd -> 
-      let t = Hashtbl.find hts fd in
-      let (finish, ts) = t.process_read t in
-      handle_result hts t finish ts) 
-    ready_fds;
+      let t = Hashtbl.find hts fd in 
+      state := process t.process_read t hts env !state) ready_fds;
   let elapsed_time = Unix.gettimeofday () -. start_time in
-  let wake_tasks = 
-    Hashtbl.fold 
-      (fun fd t ts -> 
+  let wake_tasks =
+    Hashtbl.fold
+      (fun fd t ts ->
 	match t.wake_time with
 	| None -> ts
-	| Some wake_time -> 
-	  if elapsed_time >= wake_time then 
+	| Some wake_time ->
+	  if elapsed_time >= wake_time then
 	    t :: ts
-	  else 
+	  else
 	    (t.wake_time <- Some (wake_time -. elapsed_time); ts))
       hts [] in
-  List.iter 
-    (fun t -> 
-      let (finish, ts) = t.process_wake t in
-      handle_result hts t finish ts)
-    wake_tasks;
-  eloop default_timeout hts
+  List.iter (fun t -> state := process t.process_wake t hts env !state) wake_tasks;
+  eloop default_timeout hts env !state

--- a/extraction/ocaml/Daemon.ml
+++ b/extraction/ocaml/Daemon.ml
@@ -1,0 +1,51 @@
+type task = 
+  {
+    fd : Unix.file_descr ;
+    mutable select_on : bool ;
+    mutable wake_time : float option ;
+    mutable process_read : task -> bool * task list ;
+    mutable process_wake : task -> bool * task list ;
+    finalize : task -> unit ;
+  }
+
+let handle_result hts task finish ts =
+  if finish then (Hashtbl.remove hts task.fd; task.finalize task);
+  List.iter (fun t -> Hashtbl.add hts t.fd t) ts
+
+let rec eloop default_timeout hts =
+  let start_time = Unix.gettimeofday () in
+  let (select_fds, min_timeout) = 
+    Hashtbl.fold 
+      (fun fd t (fds, timeout) ->
+	let fds' = if t.select_on then fd :: fds else fds in
+	let timeout' = 
+	  match t.wake_time with 
+	  | None -> timeout 
+	  | Some wake_time -> min timeout wake_time in
+        (fds', timeout'))
+      hts ([], default_timeout) in
+  let (ready_fds, _, _) = Unix.select select_fds [] [] min_timeout in
+  List.iter 
+    (fun fd -> 
+      let t = Hashtbl.find hts fd in
+      let (finish, ts) = t.process_read t in
+      handle_result hts t finish ts) 
+    ready_fds;
+  let elapsed_time = Unix.gettimeofday () -. start_time in
+  let wake_tasks = 
+    Hashtbl.fold 
+      (fun fd t ts -> 
+	match t.wake_time with
+	| None -> ts
+	| Some wake_time -> 
+	  if elapsed_time >= wake_time then 
+	    t :: ts
+	  else 
+	    (t.wake_time <- Some (wake_time -. elapsed_time); ts))
+      hts [] in
+  List.iter 
+    (fun t -> 
+      let (finish, ts) = t.process_wake t in
+      handle_result hts t finish ts)
+    wake_tasks;
+  eloop default_timeout hts

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -260,12 +260,15 @@ module Shim (A: ARRANGEMENT) = struct
     ; finalize =
 	(fun t env state ->
 	  let n = undenote_node env t.fd in
-	  printf "closing connection to node %s" (A.serializeName n);
+	  let read_fd = t.fd in
+	  let write_fd = denote_node env n in
+	  printf "closing connections to node %s" (A.serializeName n);
 	  print_newline ();
-	  Hashtbl.remove env.node_read_fds t.fd;
+	  Hashtbl.remove env.node_read_fds read_fd;
 	  Hashtbl.remove env.node_write_fds n;
 	  Hashtbl.remove env.cluster n;
-	  Unix.close t.fd;
+	  Unix.close read_fd;
+	  Unix.close write_fd;
 	  match A.failMsg with
           | Some m -> deliver_msg env state n m
           | None -> state)

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -327,6 +327,7 @@ module Shim (A: ARRANGEMENT) = struct
 	  printf "closing connections for node %s" (A.serializeName node_name);
 	  print_newline ();
 	  Hashtbl.remove env.node_read_fds read_fd;
+	  Hashtbl.remove env.node_fds_read node_name;
 	  Hashtbl.remove env.node_write_fds node_name;
 	  Hashtbl.remove env.cluster node_name;
 	  Unix.close read_fd;

--- a/extraction/ocaml/OrderedShim.ml
+++ b/extraction/ocaml/OrderedShim.ml
@@ -23,8 +23,8 @@ module type ARRANGEMENT = sig
   val serializeMsg : msg -> string
   val deserializeInput : string -> client_id -> input option
   val serializeOutput : output -> client_id * string
-  val failMsg : msg option
-  val newMsg : msg option
+  val failMsg : msg
+  val newMsg : msg
   val debug : bool
   val debugInput : state -> input -> unit
   val debugRecv : state -> (name * msg) -> unit
@@ -46,9 +46,10 @@ module Shim (A: ARRANGEMENT) = struct
       { cluster : (A.name, string * int) Hashtbl.t
       ; port : int
       ; me : A.name
-      ; node_fd : file_descr
-      ; client_fd : file_descr
+      ; nodes_fd : file_descr
+      ; clients_fd : file_descr
       ; node_read_fds : (file_descr, A.name) Hashtbl.t
+      ; node_fds_read : (A.name, file_descr) Hashtbl.t
       ; node_write_fds : (A.name, file_descr) Hashtbl.t
       ; client_read_fds : (file_descr, A.client_id) Hashtbl.t
       ; client_write_fds : (A.client_id, file_descr) Hashtbl.t
@@ -74,20 +75,21 @@ module Shim (A: ARRANGEMENT) = struct
   let undenote_client (env : env) (fd : file_descr) : A.client_id =
     Hashtbl.find env.client_read_fds fd
 
-  (* Gets state from the most recent snapshot, or the initial state from the arrangement. *)
+  (* Gets initial state from the arrangement *)
   let get_initial_state (env : env) : A.state =
     A.init env.me
 
-  (* Initialize environment, and start server. *)
+  (* Initialize environment *)
   let setup (cfg : cfg) : (env * A.state) =
     Random.self_init ();
     let env =
       { cluster = Hashtbl.create (List.length cfg.cluster)
       ; port = cfg.port
       ; me = cfg.me
-      ; node_fd = socket PF_INET SOCK_STREAM 0
-      ; client_fd = socket PF_INET SOCK_STREAM 0
+      ; nodes_fd = socket PF_INET SOCK_STREAM 0
+      ; clients_fd = socket PF_INET SOCK_STREAM 0
       ; node_read_fds = Hashtbl.create 17
+      ; node_fds_read = Hashtbl.create 17
       ; node_write_fds = Hashtbl.create 17
       ; client_read_fds = Hashtbl.create 17
       ; client_write_fds = Hashtbl.create 17
@@ -98,65 +100,39 @@ module Shim (A: ARRANGEMENT) = struct
     let (ip, port) = Hashtbl.find env.cluster env.me in
     let entry = gethostbyname ip in
     let listen_addr = Array.get entry.h_addr_list 0 in
-    setsockopt env.node_fd SO_REUSEADDR true;
-    setsockopt env.client_fd SO_REUSEADDR true;
-    bind env.node_fd (ADDR_INET (listen_addr, port));
-    bind env.client_fd (ADDR_INET (inet_addr_any, env.port));
-    listen env.node_fd 8;
-    listen env.client_fd 8;
+    setsockopt env.nodes_fd SO_REUSEADDR true;
+    setsockopt env.clients_fd SO_REUSEADDR true;
+    bind env.nodes_fd (ADDR_INET (listen_addr, port));
+    bind env.clients_fd (ADDR_INET (inet_addr_any, env.port));
+    listen env.nodes_fd 8;
+    listen env.clients_fd 8;
     (env, initial_state)
 
   exception Disconnect of string
 
+  (* throws Unix_error, Disconnect *)
   let send_chunk (fd : file_descr) (buf : string) : unit =
     let len = String.length buf in
     let n = Unix.send fd (raw_bytes_of_int len) 0 4 [] in
     if n < 4 then raise (Disconnect "send_chunk: message header failed to send all at once");
     let n = Unix.send fd buf 0 len [] in
     if n < len then raise (Disconnect (sprintf "send_chunk: message of length %d failed to send all at once" len))
-
-  let receive_or_raise fd buf offs len flags =
-    let n = recv fd buf offs len flags in
-    if n = 0 then raise (Disconnect "receive_or_raise: other side closed connection");
-    n
-
+  
+  (* throws Unix_error, Disconnect *)
   let receive_chunk env (fd : file_descr) : bytes =
+    let receive_check fd buf offs len flags =
+      let n = Unix.recv fd buf offs len flags in
+      if n = 0 then raise (Disconnect "receive_chunk: other side closed connection");
+      n
+    in
     let buf4 = Bytes.make 4 '\x00' in
-    let n = receive_or_raise fd buf4 0 4 [] in
+    let n = receive_check fd buf4 0 4 [] in
     if n < 4 then raise (Disconnect "receive_chunk: message header did not arrive all at once");
     let len = int_of_raw_bytes buf4 in
     let buf = Bytes.make len '\x00' in
-    let n = receive_or_raise fd buf 0 len [] in
+    let n = receive_check fd buf 0 len [] in
     if n < len then raise (Disconnect (sprintf "receive_chunk: message of length %d did not arrive all at once" len));
     buf
-
-  let add_write_fd env node_name node_addr =
-    printf "connecting to %s for the first time..." (A.serializeName node_name);
-    print_newline ();
-    let write_fd = socket PF_INET SOCK_STREAM 0 in
-    connect write_fd node_addr;
-    send_chunk write_fd (A.serializeName env.me);
-    let (ip, port) = sock_of_name env env.me in
-    send_chunk write_fd (sprintf "%s:%d" ip port);
-    begin
-      match A.newMsg with
-      | Some m -> send_chunk write_fd (A.serializeMsg m)
-      | None -> ()
-    end;
-    print_endline "...connected!";
-    Hashtbl.replace env.node_write_fds node_name write_fd;
-    write_fd
-
-  let get_node_write_fd env node_name =
-    try denote_node env node_name
-    with Not_found ->
-      if Hashtbl.mem env.cluster node_name then
-        let (ip, port) = sock_of_name env node_name in
-        let entry = gethostbyname ip in
-        let node_addr = ADDR_INET (Array.get entry.h_addr_list 0, port) in
-        add_write_fd env node_name node_addr
-      else
-        failwith "get_node_write_fd: cannot find name"
 
   let schedule_finalize_task t =
     t.select_on <- false;
@@ -164,6 +140,7 @@ module Shim (A: ARRANGEMENT) = struct
     t.process_read <- (fun t env state -> (true, [], state));
     t.process_wake <- (fun t env state -> (true, [], state))
 
+  (* throws nothing *)
   let output env o =
     let (c, out) = A.serializeOutput o in
     try send_chunk (denote_client env c) out
@@ -176,62 +153,13 @@ module Shim (A: ARRANGEMENT) = struct
       print_newline ();
       schedule_finalize_task (Hashtbl.find env.tasks (denote_client env c))
     | Unix_error (err, fn, _) ->
-      printf "error in output: %s" (error_message err);
+      printf "output: error %s" (error_message err);
       print_newline ();
       schedule_finalize_task (Hashtbl.find env.tasks (denote_client env c))
-
-  let send env ((nm : A.name), (msg : A.msg)) : unit =
-    let fd = get_node_write_fd env nm in
-    send_chunk fd (A.serializeMsg msg)
-
-  let respond env ((os, s), ps) =
-    let go p =
-      try
-        if A.debug then A.debugSend s p;
-        send env p
-      with e -> printf "respond moving on after exception: %s" (Printexc.to_string e);
-                print_newline () in
-    List.iter (output env) os;
-    List.iter go ps;
-    s
-
-  let deliver_msg env state src msg : A.state =
-    let state' = respond env (A.handleNet env.me src msg state) in
-    if A.debug then A.debugRecv state' (src, msg);
-    state'
-
-  let recv_step (env : env) (fd : file_descr) (state : A.state) : A.state =
-    let buf = receive_chunk env fd in
-    let src =
-      try undenote_node env fd
-      with Not_found -> failwith "recv_step: failed to find source for message (it has probably been marked failed)"
-    in
-    let msg = A.deserializeMsg buf in
-    deliver_msg env state src msg
-
-  let new_node_conn env =
-    printf "new node connection";
-    print_newline ();
-    let (node_fd, node_addr) = accept env.node_fd in
-    let name_buf = receive_chunk env node_fd in
-    match A.deserializeName name_buf with
-    | Some node_name ->
-      let sock_buf = receive_chunk env node_fd in
-      let sock =
-	try Scanf.sscanf sock_buf "%[^:]:%d" (fun i p -> (i, p))
-	with _ -> failwith (sprintf "new_node_conn: sscanf error %s" sock_buf)
-      in
-      Hashtbl.replace env.node_read_fds node_fd node_name;
-      Hashtbl.replace env.cluster node_name sock;
-      ignore (get_node_write_fd env node_name);
-      printf "done processing new connection from node %s" (A.serializeName node_name);
-      print_newline ();
-      node_fd
-    | None ->
-      failwith (sprintf "new_node_conn: failed to deserialize name %s" name_buf)
-
+  
+  (* throws Unix_error *)
   let new_client_conn env =
-    let (client_fd, client_addr) = accept env.client_fd in
+    let (client_fd, client_addr) = accept env.clients_fd in
     let c = A.createClientId () in
     Hashtbl.replace env.client_read_fds client_fd c;
     Hashtbl.replace env.client_write_fds c client_fd;
@@ -239,14 +167,128 @@ module Shim (A: ARRANGEMENT) = struct
     print_newline ();
     client_fd
 
+  (* throws Disconnect *)
+  let add_write_node_fd env node_name node_addr =
+    printf "connecting to %s for the first time..." (A.serializeName node_name);
+    print_newline ();
+    let write_fd = Unix.socket PF_INET SOCK_STREAM 0 in
+    try
+      Unix.connect write_fd node_addr;
+      send_chunk write_fd (A.serializeName env.me);
+      let (ip, port) = sock_of_name env env.me in
+      send_chunk write_fd (sprintf "%s:%d" ip port);
+      print_endline "...connected!";
+      Hashtbl.replace env.node_write_fds node_name write_fd;
+      write_fd
+    with
+    | Disconnect s -> Unix.close write_fd; raise (Disconnect s)
+    | Unix_error (err, fn, _) ->
+      Unix.close write_fd; raise (Disconnect (sprintf "add_write_fd: error in %s: %s" fn (error_message err)))
+
+  (* throws Disconnect *)
+  let get_write_node_fd env node_name =
+    try denote_node env node_name
+    with Not_found ->
+      try
+	let (ip, port) = sock_of_name env node_name in
+	let entry = gethostbyname ip in
+	let node_addr = ADDR_INET (Array.get entry.h_addr_list 0, port) in
+	add_write_node_fd env node_name node_addr
+      with Not_found -> raise (Disconnect "get_write_node_fd: lookup error")
+
+  (* throws Disconnect *)
+  let new_node_conn env =
+    printf "new incoming node connection";
+    print_newline ();
+    let (node_read_fd, node_addr) = accept env.nodes_fd in
+    let name_buf = 
+      try receive_chunk env node_read_fd
+      with
+      | Disconnect s -> Unix.close node_read_fd; raise (Disconnect s)
+      | Unix_error (err, fn, _) ->
+	Unix.close node_read_fd; raise (Disconnect (sprintf "new_node_conn: error in %s: %s" fn (error_message err)))
+    in 
+    match A.deserializeName name_buf with
+    | None -> Unix.close node_read_fd; raise (Disconnect (sprintf "new_node_conn: failed to deserialize name %s" name_buf))
+    | Some node_name ->
+      let sock_buf = 
+	try receive_chunk env node_read_fd 
+	with
+	| Disconnect s -> Unix.close node_read_fd; raise (Disconnect s)
+	| Unix_error (err, fn, _) -> 
+	  Unix.close node_read_fd; raise (Disconnect (sprintf "new_node_conn: error in %s: %s" fn (error_message err)))
+      in
+      let sock =
+	try Scanf.sscanf sock_buf "%[^:]:%d" (fun i p -> (i, p))
+	with _ -> Unix.close node_read_fd; raise (Disconnect (sprintf "new_node_conn: sscanf error %s" sock_buf))
+      in
+      Hashtbl.replace env.cluster node_name sock;
+      begin
+	try ignore (get_write_node_fd env node_name)
+	with Disconnect s -> Unix.close node_read_fd; raise (Disconnect s)
+      end;
+      Hashtbl.replace env.node_read_fds node_read_fd node_name;
+      Hashtbl.replace env.node_fds_read node_name node_read_fd;
+      printf "done processing new connection from node %s" (A.serializeName node_name);
+      print_newline ();
+      node_read_fd
+
+  (* throws nothing *)
   let connect_to_nodes env =
-    let go nm =
-      try ignore (get_node_write_fd env nm)
-      with e -> printf "connect_to_nodes: moving on after exception %s" (Printexc.to_string e);
-                print_newline () in
-    let ns = Hashtbl.fold (fun nm _ acc -> if nm != env.me then nm :: acc else acc) env.cluster [] in
+    let go node_name =
+      try ignore (get_write_node_fd env node_name)
+      with Disconnect s -> 
+	printf "connect_to_nodes: moving on after error for node %s: %s" (A.serializeName node_name) s;
+        print_newline ()
+    in
+    let ns = Hashtbl.fold (fun n _ acc -> if n != env.me then n :: acc else acc) env.cluster [] in
     List.iter go ns
 
+  (* throws Disconnect, Unix_error *)
+  let send_msg env node_name msg =
+    let node_fd = 
+      try denote_node env node_name
+      with Not_found -> raise (Disconnect "send_msg: message destination not found")
+    in
+    send_chunk node_fd (A.serializeMsg msg)
+
+  (* throws nothing *)
+  let respond env ((os, s), ps) = (* assume outgoing message destinations have tasks *)
+    let go ((node_name : A.name), (msg : A.msg)) =
+      try if A.debug then A.debugSend s (node_name, msg); send_msg env node_name msg
+      with
+      | Disconnect s ->
+	printf "respond: error for node %s: %s" (A.serializeName node_name) s;
+	print_newline ();
+	let task_fd = Hashtbl.find env.node_fds_read node_name in
+	schedule_finalize_task (Hashtbl.find env.tasks task_fd)
+      | Unix_error (err, fn, _) ->
+	printf "respond: error for node %s: %s" (A.serializeName node_name) (error_message err);
+	print_newline ();
+	let task_fd = Hashtbl.find env.node_fds_read node_name in
+	schedule_finalize_task (Hashtbl.find env.tasks task_fd)
+    in
+    List.iter (output env) os;
+    List.iter go ps;
+    s
+
+  (* throws nothing *)
+  let deliver_msg env state src msg : A.state =
+    let state' = respond env (A.handleNet env.me src msg state) in
+    if A.debug then A.debugRecv state' (src, msg);
+    state'
+
+  (* throws Disconnect, Unix_error *)
+  let recv_step (env : env) (fd : file_descr) (state : A.state) : A.state =
+    let buf = receive_chunk env fd in
+    let src =
+      try undenote_node env fd
+      with Not_found -> failwith "recv_step: failed to find source for message"
+    in
+    let msg = A.deserializeMsg buf in
+    deliver_msg env state src msg
+
+  (* throws Disconnect, Unix_error *)
   let input_step (fd : file_descr) (env : env) (state : A.state) =
     let buf = receive_chunk env fd in
     let c = undenote_client env fd in
@@ -256,9 +298,8 @@ module Shim (A: ARRANGEMENT) = struct
       if A.debug then A.debugInput state' inp;
       state'
     | None ->
-      failwith (sprintf "input_step: could not deserialize %s" buf)
+      raise (Disconnect (sprintf "input_step: could not deserialize %s" buf))
 
-  (* task: read node message *)
   let node_read_task fd =
     { fd = fd
     ; select_on = true
@@ -268,29 +309,31 @@ module Shim (A: ARRANGEMENT) = struct
 	  try
 	    let state' = recv_step env t.fd state in
 	    (false, [], state')
-	  with Disconnect s ->
-	    printf "connection to node %s: %s" (A.serializeName (undenote_node env t.fd)) s;
+	  with 
+	  | Disconnect s ->
+	    printf "connection error for node %s: %s" (A.serializeName (undenote_node env t.fd)) s;
+	    print_newline ();
+	    (true, [], state)
+	  | Unix_error (err, fn, _) ->
+	    printf "error for node %s: %s" (A.serializeName (undenote_node env t.fd)) (error_message err);
 	    print_newline ();
 	    (true, [], state))
     ; process_wake = (fun t env state -> (false, [], state))
     ; finalize =
 	(fun t env state ->
-	  let n = undenote_node env t.fd in
 	  let read_fd = t.fd in
-	  let write_fd = denote_node env n in
-	  printf "closing connections to node %s" (A.serializeName n);
+	  let node_name = undenote_node env read_fd in
+	  let write_fd = denote_node env node_name in (* assumed to never throw Not_found *)
+	  printf "closing connections for node %s" (A.serializeName node_name);
 	  print_newline ();
 	  Hashtbl.remove env.node_read_fds read_fd;
-	  Hashtbl.remove env.node_write_fds n;
-	  Hashtbl.remove env.cluster n;
+	  Hashtbl.remove env.node_write_fds node_name;
+	  Hashtbl.remove env.cluster node_name;
 	  Unix.close read_fd;
 	  Unix.close write_fd;
-	  match A.failMsg with
-          | Some m -> deliver_msg env state n m
-          | None -> state)
+          deliver_msg env state node_name A.failMsg)
     }
 
-  (* task: read client input *)
   let client_read_task fd =
     { fd = fd
     ; select_on = true
@@ -300,81 +343,89 @@ module Shim (A: ARRANGEMENT) = struct
 	  try
 	    let state' = input_step t.fd env state in
 	    (false, [], state')
-	  with Disconnect s ->
-	    printf "connection to client %s: %s" (A.serializeClientId (undenote_client env t.fd)) s;
+	  with 
+	  | Disconnect s ->
+	    printf "connection error for client %s: %s" (A.serializeClientId (undenote_client env t.fd)) s;
+	    print_newline ();
+	    (true, [], state)
+	  | Unix_error (err, fn, _) ->
+	    printf "error for client %s: %s" (A.serializeClientId (undenote_client env t.fd)) (error_message err);
 	    print_newline ();
 	    (true, [], state))
     ; process_wake = (fun t env state -> (false, [], state))
     ; finalize =
 	(fun t env state ->
-	  let c = undenote_client env t.fd in
+	  let client_fd = t.fd in
+	  let c = undenote_client env client_fd in
 	  printf "closing connection to client %s" (A.serializeClientId c);
 	  print_newline ();
-	  Hashtbl.remove env.client_read_fds t.fd;
+	  Hashtbl.remove env.client_read_fds client_fd;
 	  Hashtbl.remove env.client_write_fds c;
-	  Unix.close t.fd;
+	  Unix.close client_fd;
 	  state)
     }
 
-  let main (cfg : cfg) : unit =
-    printf "ordered shim running setup for %s" A.systemName;
-    print_newline ();
-    let (env, initial_state) = setup cfg in
-    let t_conn_nd = (* connect to neighbors in cluster *)
-      { fd = Unix.dup env.node_fd
+  let connect_to_nodes_task env =
+    { fd = Unix.dup env.nodes_fd
       ; select_on = false
       ; wake_time = Some 1.0
       ; process_read = (fun t env state -> (false, [], state))
       ; process_wake =
 	  (fun t env state ->
-	    begin
-	      try connect_to_nodes env
-	      with Disconnect s ->
-		printf "connecting to nodes in cluster: %s" s;
-		print_newline ()
-	    end;
+	    connect_to_nodes env;
 	    t.wake_time <- Some 1.0;
 	    (false, [], state))
       ; finalize = (fun t env state -> Unix.close t.fd; state)
-      } in
-    let t_nd_conn = (* listen to neighbors connecting *)
-      { fd = env.node_fd
-      ; select_on = true
-      ; wake_time = None
-      ; process_read =
-	  (fun t env state ->
-	    try
-	      let node_fd = new_node_conn env in
-	      (false, [node_read_task node_fd], state)
-	    with Disconnect s ->
-	      printf "incoming node connection: %s" s;
-	      print_newline ();
-	      (false, [], state))
-      ; process_wake = (fun t env state -> (false, [], state))
-      ; finalize = (fun t env state -> Unix.close t.fd; state)
-      } in
-    let t_cl_conn = (* listen to clients connecting *)
-      { fd = env.client_fd
-      ; select_on = true
-      ; wake_time = None
-      ; process_read =
-	  (fun t env state ->
-	    try
-	      let client_fd = new_client_conn env in
-	      (false, [client_read_task client_fd], state)
-	    with Disconnect s ->
-	      printf "incoming client connection: %s" s;
-	      print_newline ();
-	      (false, [], state))
-      ; process_wake = (fun t env state -> (false, [], state))
-      ; finalize = (fun t env state -> Unix.close t.fd; state)
-      } in
+      }
+
+  let node_connections_task env =
+    { fd = env.nodes_fd
+    ; select_on = true
+    ; wake_time = None
+    ; process_read =
+	(fun t env state ->
+	  try
+	    let node_fd = new_node_conn env in
+	    let state' = deliver_msg env state (Hashtbl.find env.node_read_fds node_fd) A.newMsg in
+	    (false, [node_read_task node_fd], state')
+	  with Disconnect s ->
+	    printf "incoming node connection error: %s" s;
+	    print_newline ();
+	    (false, [], state))
+    ; process_wake = (fun t env state -> (false, [], state))
+    ; finalize = (fun t env state -> Unix.close t.fd; state)
+    }
+
+  let client_connections_task env =
+    { fd = env.clients_fd
+    ; select_on = true
+    ; wake_time = None
+    ; process_read =
+	(fun t env state ->
+	  try
+	    let client_fd = new_client_conn env in
+	    (false, [client_read_task client_fd], state)
+	  with Unix_error (err, fn, _) ->
+	    printf "incoming client connection error in %s: %s" fn (error_message err);
+	    print_newline ();
+	    (false, [], state))
+    ; process_wake = (fun t env state -> (false, [], state))
+    ; finalize = (fun t env state -> Unix.close t.fd; state)
+    }
+ 
+  let main (cfg : cfg) : unit =
+    printf "ordered dynamic shim running setup for %s" A.systemName;
+    print_newline ();
+    let (env, initial_state) = setup cfg in
+    let t_conn_nd = connect_to_nodes_task env in
+    let t_nd_conn = node_connections_task env in
+    let t_cl_conn = client_connections_task env in
     Hashtbl.add env.tasks t_conn_nd.fd t_conn_nd;
     Hashtbl.add env.tasks t_nd_conn.fd t_nd_conn;
     Hashtbl.add env.tasks t_cl_conn.fd t_cl_conn;
     List.iter (fun (handler, setter) ->
       let t_hnd =
-	{ fd = Unix.dup env.client_fd
+	{ fd = Unix.dup env.clients_fd
 	; select_on = false
 	; wake_time = Some (setter env.me initial_state)
 	; process_read = (fun t env state -> (false, [], state))
@@ -386,6 +437,6 @@ module Shim (A: ARRANGEMENT) = struct
 	; finalize = (fun t env state -> Unix.close t.fd; state)
 	}
       in Hashtbl.add env.tasks t_hnd.fd t_hnd) A.timeoutTasks;
-    print_endline "ordered shim ready for action";
+    print_endline "ordered dynamic shim ready for action";
     eloop 2.0 (Unix.gettimeofday ()) env.tasks env initial_state
 end

--- a/extraction/ocaml/Shim.ml
+++ b/extraction/ocaml/Shim.ml
@@ -167,12 +167,14 @@ module Shim (A: ARRANGEMENT) = struct
   let send_to_client env fd out =
     try ignore (Unix.send fd (out ^ "\n") 0 (String.length out) [])
     with Unix_error (err, fn, arg) ->
-      disconnect_client env fd ("error in send: " ^ (error_message err))
+      disconnect_client env fd (sprintf "error in send_to_client: %s" (error_message err))
 
   let output env o =
     let (c, out) = A.serializeOutput o in
     try send_to_client env (denote_client env c) out
-    with Not_found -> printf "output: failed to find socket for client %s" (A.serializeClientId c)
+    with Not_found ->
+      printf "output: failed to find socket for client %s" (A.serializeClientId c);
+      print_newline ()
 
   let save env (step : log_step) (st : A.state)  =
     if (env.saves > 0 && env.saves mod 1000 = 0) then begin

--- a/extraction/ocaml/Shim.ml
+++ b/extraction/ocaml/Shim.ml
@@ -171,10 +171,8 @@ module Shim (A: ARRANGEMENT) = struct
 
   let output env o =
     let (c, out) = A.serializeOutput o in
-    let fd =
-      try denote_client env c
-      with Not_found -> failwith "output: failed to find destination client" in
-    send_to_client env fd out
+    try send_to_client env (denote_client env c) out
+    with Not_found -> printf "output: failed to find socket for client %s" (A.serializeClientId c)
 
   let save env (step : log_step) (st : A.state)  =
     if (env.saves > 0 && env.saves mod 1000 = 0) then begin

--- a/extraction/ocaml/Shim.ml
+++ b/extraction/ocaml/Shim.ml
@@ -189,7 +189,7 @@ module Shim (A: ARRANGEMENT) = struct
 
   let respond env ((os, s), ps) =
     List.iter (output env) os;
-    List.iter (fun p -> (if A.debug then A.debugSend s p); send env p) ps;
+    List.iter (fun p -> if A.debug then A.debugSend s p; send env p) ps;
     s
 
   let new_conn env =
@@ -227,9 +227,7 @@ module Shim (A: ARRANGEMENT) = struct
     | Some inp ->
       save env (LogInput inp) state;
       let state' = respond env (A.handleIO env.cfg.me inp state) in
-      if A.debug then begin
-	 A.debugInput state' inp
-      end;
+      if A.debug then A.debugInput state' inp;
       state'
     | None ->
       raise (Disconnect_client (S_error, "received invalid input"))
@@ -241,16 +239,12 @@ module Shim (A: ARRANGEMENT) = struct
     let (src, msg) = (undenote env from, A.deserializeMsg buf) in
     save env (LogNet (src, msg)) state;
     let state' = respond env (A.handleNet env.cfg.me src msg state) in
-    if A.debug then begin
-      A.debugRecv state' (src, msg)
-    end;
+    if A.debug then A.debugRecv state' (src, msg);
     state'
 
   let timeout_step (env : env) (state : A.state) : A.state =
     save env LogTimeout state;
-    if A.debug then begin
-      A.debugTimeout state
-    end;
+    if A.debug then A.debugTimeout state;
     let x = A.handleTimeout env.cfg.me state in
     respond env x
 

--- a/extraction/ocaml/Shim.ml
+++ b/extraction/ocaml/Shim.ml
@@ -277,7 +277,7 @@ module Shim (A: ARRANGEMENT) = struct
     let state' =
       match ready_fds with
       | [] -> timeout_step env state
-      | _ -> List.fold_left (fun st fd -> process_fd env st fd) state ready_fds in
+      | _ -> List.fold_left (process_fd env) state ready_fds in
     eloop env state'
 
   let main (cfg : cfg) : unit =


### PR DESCRIPTION
Refactoring of ordered shim to use cleanly separated fair event loop and perform error handling. Slight refactoring of unordered shim client handling, error messages, and fair treatment of file descriptors.

Commits db9a4a4 and d345cec should not be included in the merge, since they only change the verdi-raft branch to build against.