### PR TITLE
Uniform use of Verdi namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=master
+    - VERDI_RAFT_BRANCH=fix-extraction-namespace
     - STRUCTTACT_BRANCH=master
   matrix:
     - DOWNSTREAM=none

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ default: Makefile.coq
 quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
 
+install: Makefile.coq
+	$(MAKE) -f Makefile.coq install
+
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 
@@ -37,4 +40,4 @@ lint:
 distclean: clean
 	rm -f _CoqProject
 
-.PHONY: default quick clean lint distclean
+.PHONY: default quick clean lint distclean install

--- a/configure
+++ b/configure
@@ -7,5 +7,7 @@ DEPS=(StructTact InfSeqExt)
 DIRS=(core lib systems extraction/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi" "InfSeqExt.infseq" "Build InfSeqExt before building Verdi")
 NAMESPACE_core="Verdi"
+NAMESPACE_lib="Verdi"
 NAMESPACE_systems="Verdi"
+NAMESPACE_extraction_coq="Verdi"
 source script/coqproject.sh

--- a/lib/Maps.v
+++ b/lib/Maps.v
@@ -33,7 +33,7 @@
 *)
 
 Require Import Equivalence EquivDec.
-Require Import Coqlib.
+Require Import Verdi.Coqlib.
 Require Import StructTact.StructTactics.
 Require Import StructTact.Util.
 

--- a/lib/StringMap.v
+++ b/lib/StringMap.v
@@ -4,9 +4,9 @@ Require Import NArith.
 Require Import PArith.
 Require Import String.
 
-Require Import Coqlib.
+Require Import Verdi.Coqlib.
 Require Import StructTact.StructTactics.
-Require Export Maps.
+Require Export Verdi.Maps.
 
 Module ITree(X: INDEXED_TYPE) <: TREE.
 

--- a/systems/VarD.v
+++ b/systems/VarD.v
@@ -1,7 +1,7 @@
 Require Import Verdi.Verdi.
 
 Require Import String.
-Require Import StringMap.
+Require Import Verdi.StringMap.
 
 Require Import Verdi.StateMachineHandlerMonad.
 


### PR DESCRIPTION
To prepare for making an OPAM package of Verdi, this PR makes sure that the `Verdi` namespace is used for every Coq file, and introduces an `install` Makefile task.

Commit 2ca9651 should not be included when merging.