### PR TITLE
more straightforward names for liveness-related concepts

### DIFF
--- a/core/LabeledNet.v
+++ b/core/LabeledNet.v
@@ -56,37 +56,37 @@ Section LabeledStepExecution.
 
   Definition lb_step_relation := A -> L -> A -> list trace -> Prop.
 
-  Record event := { evt_a : A ; evt_l : L ; evt_trace : list trace }.
-
-  Definition enabled (step : lb_step_relation) (l : L) (a : A) : Prop :=
+  Definition lb_step_ex (step : lb_step_relation) (l : L) (a : A) : Prop :=
   exists a' tr, step a l a' tr.
 
-  Definition l_enabled (step : lb_step_relation) (l : L) (e : event) : Prop :=
-  enabled step l (evt_a e).
+  Record event := { evt_a : A ; evt_l : L ; evt_trace : list trace }.
+
+  Definition enabled (step : lb_step_relation) (l : L) (e : event) : Prop :=
+    lb_step_ex step l (evt_a e).
 
   Definition occurred (l : L) (e : event) : Prop := l = evt_l e.
 
   Definition inf_enabled (step : lb_step_relation) (l : L) (s : infseq event) : Prop :=
-    inf_often (now (l_enabled step l)) s.
+    inf_often (now (enabled step l)) s.
 
   Definition cont_enabled (step : lb_step_relation) (l : L) (s : infseq event) : Prop :=
-    continuously (now (l_enabled step l)) s.
+    continuously (now (enabled step l)) s.
 
   Definition inf_occurred (l : L) (s : infseq event) : Prop :=
     inf_often (now (occurred l)) s.
 
-  Definition strong_local_fairness (step : lb_step_relation) (silent : L) (s : infseq event) : Prop :=
+  Definition strong_fairness (step : lb_step_relation) (silent : L) (s : infseq event) : Prop :=
     forall l : L, l <> silent -> inf_enabled step l s -> inf_occurred l s.
 
-  Definition weak_local_fairness (step : lb_step_relation) (silent : L) (s : infseq event) : Prop :=
+  Definition weak_fairness (step : lb_step_relation) (silent : L) (s : infseq event) : Prop :=
     forall l : L, l <> silent -> cont_enabled step l s -> inf_occurred l s.
 
-  Lemma strong_local_fairness_invar :
-    forall step e silent s, strong_local_fairness step silent (Cons e s) -> strong_local_fairness step silent s.
+  Lemma strong_fairness_invar :
+    forall step e silent s, strong_fairness step silent (Cons e s) -> strong_fairness step silent s.
   Proof using. 
-    unfold strong_local_fairness. unfold inf_enabled, inf_occurred, inf_often. 
+    unfold strong_fairness. unfold inf_enabled, inf_occurred, inf_often.
     intros step e silent s fair l neq alev. 
-    assert (alevt_es: always (eventually (now (l_enabled step l))) (Cons e s)).
+    assert (alevt_es: always (eventually (now (enabled step l))) (Cons e s)).
     constructor. 
     constructor 2. destruct alev; assumption. 
     simpl. assumption.
@@ -94,11 +94,11 @@ Section LabeledStepExecution.
     intro fair; case (always_Cons fair); trivial.
   Qed.
 
-  Lemma strong_local_fairness_extensional :
-    forall step silent, extensional (strong_local_fairness step silent).
+  Lemma strong_fairness_extensional :
+    forall step silent, extensional (strong_fairness step silent).
   Proof using.
     move => step silent.
-    rewrite /extensional /strong_local_fairness /inf_enabled /inf_occurred /=.
+    rewrite /extensional /strong_fairness /inf_enabled /inf_occurred /=.
     move => s1 s2 H_eq H_s1 l' H_neq' H_en.
     have H_s1l := H_s1 l'.
     move: H_s1l.
@@ -114,12 +114,12 @@ Section LabeledStepExecution.
     exact: extensional_now.
   Qed.
 
-  Lemma weak_local_fairness_invar :
-    forall step e silent s, weak_local_fairness step silent (Cons e s) -> weak_local_fairness step silent s.
+  Lemma weak_fairness_invar :
+    forall step e silent s, weak_fairness step silent (Cons e s) -> weak_fairness step silent s.
   Proof using.
-    unfold weak_local_fairness. unfold cont_enabled, inf_occurred, continuously, inf_often.
+    unfold weak_fairness. unfold cont_enabled, inf_occurred, continuously, inf_often.
     intros step e silent s fair a neq eval.
-    assert (eval_es: eventually (always (now (l_enabled step a))) (Cons e s)).
+    assert (eval_es: eventually (always (now (enabled step a))) (Cons e s)).
       apply E_next. assumption.
     apply fair in eval_es.
     apply always_invar in eval_es.
@@ -127,11 +127,11 @@ Section LabeledStepExecution.
     assumption.
   Qed.
 
-  Lemma weak_local_fairness_extensional :
-    forall step silent, extensional (weak_local_fairness step silent).
+  Lemma weak_fairness_extensional :
+    forall step silent, extensional (weak_fairness step silent).
   Proof using.
   move => step silent.
-  rewrite /extensional /weak_local_fairness /cont_enabled /inf_occurred /=.
+  rewrite /extensional /weak_fairness /cont_enabled /inf_occurred /=.
   move => s1 s2 H_eq H_s1 l' H_neq' H_en.
   have H_s1l := H_s1 l'.
   move: H_s1l.
@@ -147,12 +147,12 @@ Section LabeledStepExecution.
   exact: extensional_now.
   Qed.
 
-  Lemma strong_local_fairness_weak :
-    forall step silent s, strong_local_fairness step silent s -> weak_local_fairness step silent s.
+  Lemma strong_fairness_weak :
+    forall step silent s, strong_fairness step silent s -> weak_fairness step silent s.
   Proof using.
   move => step silent.
   case => e s.
-  rewrite /strong_local_fairness /weak_local_fairness /inf_enabled /cont_enabled.
+  rewrite /strong_fairness /weak_fairness /inf_enabled /cont_enabled.
   move => H_str l neq H_cont.
   apply: H_str; first by [].
   exact: continuously_inf_often.

--- a/core/PartialMapExecutionSimulations.v
+++ b/core/PartialMapExecutionSimulations.v
@@ -470,35 +470,35 @@ Qed.
 Hypothesis lb_step_ordered_failure_strong_fairness_enabled_pt_map_onet_eventually :
   forall l, tot_map_label l <> label_silent ->
     forall s, lb_step_execution lb_step_ordered_failure s ->
-    strong_local_fairness lb_step_ordered_failure label_silent s ->        
-    l_enabled lb_step_ordered_failure (tot_map_label l) (pt_map_onet_event (hd s)) ->
-    eventually (now (l_enabled lb_step_ordered_failure l)) s.
+    strong_fairness lb_step_ordered_failure label_silent s ->
+    enabled lb_step_ordered_failure (tot_map_label l) (pt_map_onet_event (hd s)) ->
+    eventually (now (enabled lb_step_ordered_failure l)) s.
 
 Lemma pt_map_onet_tot_map_labeled_event_inf_often_enabled :
   forall l, tot_map_label l <> label_silent ->
     forall s, lb_step_execution lb_step_ordered_failure s ->
-    strong_local_fairness lb_step_ordered_failure label_silent s ->
-    inf_often (now (l_enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
-    inf_often (now (l_enabled lb_step_ordered_failure l)) s.
+    strong_fairness lb_step_ordered_failure label_silent s ->
+    inf_often (now (enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
+    inf_often (now (enabled lb_step_ordered_failure l)) s.
 Proof using lb_step_ordered_failure_strong_fairness_enabled_pt_map_onet_eventually.
 move => l H_neq s H_exec H_fair.
-have H_a: ((lb_step_execution lb_step_ordered_failure) /\_ (strong_local_fairness lb_step_ordered_failure label_silent)) s by auto.
+have H_a: ((lb_step_execution lb_step_ordered_failure) /\_ (strong_fairness lb_step_ordered_failure label_silent)) s by auto.
 move: H_a {H_exec H_fair}.
 apply: always_map_conv_ext => {s}.
   rewrite /and_tl /=.
   move => x s0 [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply strong_local_fairness_invar in H_w.
+  by apply strong_fairness_invar in H_w.
 apply: eventually_map_conv_ext.
 - exact: extensional_now.
 - exact: extensional_now.
 - apply extensional_and_tl.
   * exact: lb_step_execution_extensional.
-  * exact: strong_local_fairness_extensional.
+  * exact: strong_fairness_extensional.
 - rewrite /and_tl /=.
   move => x s [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply strong_local_fairness_invar in H_w.
+  by apply strong_fairness_invar in H_w.
 - rewrite /and_tl.
   case => /= x s [H_a H_w] H_en.
   exact: lb_step_ordered_failure_strong_fairness_enabled_pt_map_onet_eventually.
@@ -507,19 +507,19 @@ Qed.
 Hypothesis lb_step_ordered_failure_weak_fairness_always_enabled_pt_map_onet_continuously : 
   forall l, tot_map_label l <> label_silent -> 
     forall s, lb_step_execution lb_step_ordered_failure s ->
-    weak_local_fairness lb_step_ordered_failure label_silent s ->
-    always (now (l_enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
-    continuously (now (l_enabled lb_step_ordered_failure l)) s.
+    weak_fairness lb_step_ordered_failure label_silent s ->
+    always (now (enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
+    continuously (now (enabled lb_step_ordered_failure l)) s.
 
 Lemma pt_map_onet_tot_map_labeled_event_state_continuously_enabled :
   forall l, tot_map_label l <> label_silent ->    
     forall s, lb_step_execution lb_step_ordered_failure s ->
-    weak_local_fairness lb_step_ordered_failure label_silent s ->
-    continuously (now (l_enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
-    continuously (now (l_enabled lb_step_ordered_failure l)) s.
+    weak_fairness lb_step_ordered_failure label_silent s ->
+    continuously (now (enabled lb_step_ordered_failure (tot_map_label l))) (map pt_map_onet_event s) ->
+    continuously (now (enabled lb_step_ordered_failure l)) s.
 Proof using lb_step_ordered_failure_weak_fairness_always_enabled_pt_map_onet_continuously.
 move => l H_neq s H_exec H_fair.
-have H_a: ((lb_step_execution lb_step_ordered_failure) /\_ (weak_local_fairness lb_step_ordered_failure label_silent)) s by auto.
+have H_a: ((lb_step_execution lb_step_ordered_failure) /\_ (weak_fairness lb_step_ordered_failure label_silent)) s by auto.
 move: H_a {H_exec H_fair}.
 apply: eventually_map_conv_ext => {s}.
 - apply extensional_always.
@@ -528,23 +528,23 @@ apply: eventually_map_conv_ext => {s}.
   exact: extensional_now.
 - apply extensional_and_tl.
   * exact: lb_step_execution_extensional.
-  * exact: weak_local_fairness_extensional.
+  * exact: weak_fairness_extensional.
 - rewrite /and_tl /=.
   move => x s [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply weak_local_fairness_invar in H_w.
+  by apply weak_fairness_invar in H_w.
 - case => x s [H_a H_w] H_al.
   simpl in *.
   exact: lb_step_ordered_failure_weak_fairness_always_enabled_pt_map_onet_continuously.
 Qed.
 
-Lemma pt_map_onet_tot_map_label_event_strong_local_fairness : 
+Lemma pt_map_onet_tot_map_label_event_strong_fairness :
   forall s, lb_step_execution lb_step_ordered_failure s ->
-       strong_local_fairness lb_step_ordered_failure label_silent s ->
-       strong_local_fairness lb_step_ordered_failure label_silent (map pt_map_onet_event s).
+       strong_fairness lb_step_ordered_failure label_silent s ->
+       strong_fairness lb_step_ordered_failure label_silent (map pt_map_onet_event s).
 Proof using multi_map_lb_congr lb_step_ordered_failure_strong_fairness_enabled_pt_map_onet_eventually label_tot_mapped.
 move => s.
-rewrite /strong_local_fairness => H_exec H_fair l H_neq H_en.
+rewrite /strong_fairness => H_exec H_fair l H_neq H_en.
 have [l' H_l] := label_tot_mapped l.
 rewrite H_l.
 apply pt_map_onet_tot_map_label_event_inf_often_occurred.
@@ -556,13 +556,13 @@ move => H_eq.
 by rewrite -H_l in H_eq.
 Qed.
 
-Lemma pt_map_onet_tot_map_label_event_state_weak_local_fairness : 
+Lemma pt_map_onet_tot_map_label_event_state_weak_fairness :
   forall s, lb_step_execution lb_step_ordered_failure s ->
-       weak_local_fairness lb_step_ordered_failure label_silent s ->
-       weak_local_fairness lb_step_ordered_failure label_silent (map pt_map_onet_event s).
+       weak_fairness lb_step_ordered_failure label_silent s ->
+       weak_fairness lb_step_ordered_failure label_silent (map pt_map_onet_event s).
 Proof using multi_map_lb_congr lb_step_ordered_failure_weak_fairness_always_enabled_pt_map_onet_continuously label_tot_mapped.
 move => s.
-rewrite /weak_local_fairness => H_exec H_fair l H_neq H_en.
+rewrite /weak_fairness => H_exec H_fair l H_neq H_en.
 have [l' H_l] := label_tot_mapped l.
 rewrite H_l.
 apply pt_map_onet_tot_map_label_event_inf_often_occurred.
@@ -853,35 +853,35 @@ Qed.
 Hypothesis lb_step_ordered_dynamic_failure_strong_fairness_enabled_pt_map_onet_eventually :
   forall l, tot_map_label l <> label_silent ->
     forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-    strong_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-    l_enabled lb_step_ordered_dynamic_failure (tot_map_label l) (pt_map_odnet_event (hd s)) ->
-    eventually (now (l_enabled lb_step_ordered_dynamic_failure l)) s.
+    strong_fairness lb_step_ordered_dynamic_failure label_silent s ->
+    enabled lb_step_ordered_dynamic_failure (tot_map_label l) (pt_map_odnet_event (hd s)) ->
+    eventually (now (enabled lb_step_ordered_dynamic_failure l)) s.
 
 Lemma pt_map_odnet_tot_map_labeled_event_inf_often_enabled :
   forall l, tot_map_label l <> label_silent ->
     forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-    strong_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-    inf_often (now (l_enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
-    inf_often (now (l_enabled lb_step_ordered_dynamic_failure l)) s.
+    strong_fairness lb_step_ordered_dynamic_failure label_silent s ->
+    inf_often (now (enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
+    inf_often (now (enabled lb_step_ordered_dynamic_failure l)) s.
 Proof using lb_step_ordered_dynamic_failure_strong_fairness_enabled_pt_map_onet_eventually.
 move => l H_neq s H_exec H_fair.
-have H_a: ((lb_step_execution lb_step_ordered_dynamic_failure) /\_ (strong_local_fairness lb_step_ordered_dynamic_failure label_silent)) s by auto.
+have H_a: ((lb_step_execution lb_step_ordered_dynamic_failure) /\_ (strong_fairness lb_step_ordered_dynamic_failure label_silent)) s by auto.
 move: H_a {H_exec H_fair}.
 apply: always_map_conv_ext => {s}.
   rewrite /and_tl /=.
   move => x s0 [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply strong_local_fairness_invar in H_w.
+  by apply strong_fairness_invar in H_w.
 apply: eventually_map_conv_ext.
 - exact: extensional_now.
 - exact: extensional_now.
 - apply extensional_and_tl.
   * exact: lb_step_execution_extensional.
-  * exact: strong_local_fairness_extensional.
+  * exact: strong_fairness_extensional.
 - rewrite /and_tl /=.
   move => x s [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply strong_local_fairness_invar in H_w.
+  by apply strong_fairness_invar in H_w.
 - rewrite /and_tl.
   case => /= x s [H_a H_w] H_en.
   exact: lb_step_ordered_dynamic_failure_strong_fairness_enabled_pt_map_onet_eventually.
@@ -890,19 +890,19 @@ Qed.
 Hypothesis lb_step_ordered_dynamic_failure_weak_fairness_always_enabled_pt_map_onet_continuously : 
   forall l, tot_map_label l <> label_silent -> 
     forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-    weak_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-    always (now (l_enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
-    continuously (now (l_enabled lb_step_ordered_dynamic_failure l)) s.
+    weak_fairness lb_step_ordered_dynamic_failure label_silent s ->
+    always (now (enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
+    continuously (now (enabled lb_step_ordered_dynamic_failure l)) s.
 
 Lemma pt_map_odnet_tot_map_labeled_event_state_continuously_enabled :
   forall l, tot_map_label l <> label_silent ->    
     forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-    weak_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-    continuously (now (l_enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
-    continuously (now (l_enabled lb_step_ordered_dynamic_failure l)) s.
+    weak_fairness lb_step_ordered_dynamic_failure label_silent s ->
+    continuously (now (enabled lb_step_ordered_dynamic_failure (tot_map_label l))) (map pt_map_odnet_event s) ->
+    continuously (now (enabled lb_step_ordered_dynamic_failure l)) s.
 Proof using lb_step_ordered_dynamic_failure_weak_fairness_always_enabled_pt_map_onet_continuously.
 move => l H_neq s H_exec H_fair.
-have H_a: ((lb_step_execution lb_step_ordered_dynamic_failure) /\_ (weak_local_fairness lb_step_ordered_dynamic_failure label_silent)) s by auto.
+have H_a: ((lb_step_execution lb_step_ordered_dynamic_failure) /\_ (weak_fairness lb_step_ordered_dynamic_failure label_silent)) s by auto.
 move: H_a {H_exec H_fair}.
 apply: eventually_map_conv_ext => {s}.
 - apply extensional_always.
@@ -911,23 +911,23 @@ apply: eventually_map_conv_ext => {s}.
   exact: extensional_now.
 - apply extensional_and_tl.
   * exact: lb_step_execution_extensional.
-  * exact: weak_local_fairness_extensional.
+  * exact: weak_fairness_extensional.
 - rewrite /and_tl /=.
   move => x s [H_e H_w].
   apply lb_step_execution_invar in H_e.
-  by apply weak_local_fairness_invar in H_w.
+  by apply weak_fairness_invar in H_w.
 - case => x s [H_a H_w] H_al.
   simpl in *.
   exact: lb_step_ordered_dynamic_failure_weak_fairness_always_enabled_pt_map_onet_continuously.
 Qed.
 
-Lemma pt_map_odnet_tot_map_label_event_strong_local_fairness :
+Lemma pt_map_odnet_tot_map_label_event_strong_fairness :
   forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-       strong_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-       strong_local_fairness lb_step_ordered_dynamic_failure label_silent (map pt_map_odnet_event s).
+       strong_fairness lb_step_ordered_dynamic_failure label_silent s ->
+       strong_fairness lb_step_ordered_dynamic_failure label_silent (map pt_map_odnet_event s).
 Proof using multi_map_lb_congr lb_step_ordered_dynamic_failure_strong_fairness_enabled_pt_map_onet_eventually label_tot_mapped.
 move => s.
-rewrite /strong_local_fairness => H_exec H_fair l H_neq H_en.
+rewrite /strong_fairness => H_exec H_fair l H_neq H_en.
 have [l' H_l] := label_tot_mapped l.
 rewrite H_l.
 apply pt_map_odnet_tot_map_label_event_inf_often_occurred.
@@ -939,13 +939,13 @@ move => H_eq.
 by rewrite -H_l in H_eq.
 Qed.
 
-Lemma pt_map_odnet_tot_map_label_event_state_weak_local_fairness : 
+Lemma pt_map_odnet_tot_map_label_event_state_weak_fairness :
   forall s, lb_step_execution lb_step_ordered_dynamic_failure s ->
-       weak_local_fairness lb_step_ordered_dynamic_failure label_silent s ->
-       weak_local_fairness lb_step_ordered_dynamic_failure label_silent (map pt_map_odnet_event s).
+       weak_fairness lb_step_ordered_dynamic_failure label_silent s ->
+       weak_fairness lb_step_ordered_dynamic_failure label_silent (map pt_map_odnet_event s).
 Proof using multi_map_lb_congr lb_step_ordered_dynamic_failure_weak_fairness_always_enabled_pt_map_onet_continuously label_tot_mapped.
 move => s.
-rewrite /weak_local_fairness => H_exec H_fair l H_neq H_en.
+rewrite /weak_fairness => H_exec H_fair l H_neq H_en.
 have [l' H_l] := label_tot_mapped l.
 rewrite H_l.
 apply pt_map_odnet_tot_map_label_event_inf_often_occurred.


### PR DESCRIPTION
`l_enabled` didn't make much sense, and the `local` part of fairness is obsolete.