### PR TITLE
Use update function in reboot step of failure semantics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - COQ_VERSION=8.5.3
     - SSREFLECT_VERSION=1.6
-    - VERDI_RAFT_BRANCH=master
+    - VERDI_RAFT_BRANCH=reboot-update
   matrix:
     - DOWNSTREAM=none
     - DOWNSTREAM=verdi-raft

--- a/core/Net.v
+++ b/core/Net.v
@@ -418,10 +418,7 @@ Section StepFailure.
       In h failed ->
       failed' = remove name_eq_dec h failed ->
       net' = mkNetwork (nwPackets net)
-                       (fun nm => if name_eq_dec nm h then
-                                   (reboot (nwState net nm))
-                                 else
-                                   (nwState net nm)) ->
+                       (update name_eq_dec (nwState net) h (reboot (nwState net h))) ->
       step_failure (failed, net) (failed', net') [].
 
   Definition step_failure_star : step_relation (list name * network) (name * (input + list output)) :=

--- a/core/PartialMapSimulations.v
+++ b/core/PartialMapSimulations.v
@@ -475,16 +475,8 @@ invcs H_step.
 - rewrite remove_tot_map_eq /=.
   left.
   rewrite {2}/pt_map_net /=.
-  apply: (StepFailure_reboot (tot_map_name h)) => //; first exact: in_failed_in.
-  set nwS1 := fun _ => _.
-  set nwS2 := fun _ => _.
-  suff H_suff: nwS1 = nwS2 by rewrite H_suff.
-  rewrite /nwS1 /nwS2.
-  apply functional_extensionality => n.
-  break_if; break_if => //.
-  * by rewrite /pt_map_net /= pt_reboot_eq.
-  * by rewrite -e tot_map_name_inverse_inv in n0.
-  * by rewrite e tot_map_name_inv_inverse in n0.
+  eapply (@StepFailure_reboot _ _ _ (tot_map_name h)) => //; first exact: in_failed_in.
+  by rewrite pt_map_update_eq /pt_map_net pt_reboot_eq /= tot_map_name_inv_inverse.
 Qed.
 
 Corollary step_failure_pt_mapped_simulation_star_1 :


### PR DESCRIPTION
Consistent use of update function simplifies proofs.