### PR TITLE
Support Coq 8.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-COQVERSION := $(shell coqc --version|grep "version 8.5")
+COQVERSION := $(shell coqc --version|egrep "version (8\\.5|8\\.6)")
 
 ifeq "$(COQVERSION)" ""
-$(error "Verdi is only compatible with Coq version 8.5")
+$(error "Verdi is only compatible with Coq version 8.5 or 8.6")
 endif
 
 COQPROJECT_EXISTS=$(wildcard _CoqProject)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements
 
 Framework:
 
-- [`Coq 8.5`](https://coq.inria.fr/coq-85)
+- [`Coq 8.5`](https://coq.inria.fr/coq-85) or [`Coq 8.6`](https://coq.inria.fr/coq-86)
 - [`Mathematical Components 1.6`](http://math-comp.github.io/math-comp/) (`ssreflect` library)
 - [`StructTact`](https://github.com/uwplse/StructTact)
 - [`InfSeqExt`](https://github.com/DistributedComponents/InfSeqExt)

--- a/core/DupDropReordering.v
+++ b/core/DupDropReordering.v
@@ -169,7 +169,7 @@ Section dup_drop_reorder.
         eapply dup_drop_step_star_step_1.
         apply DDS_dup; auto.
       + pose proof dup_drop_in l _ a ltac:(eauto).
-        concludes.
+        try concludes. (* Only needed in Coq 8.5 *)
         eapply dup_drop_step_star_step_n1 in H0; [| eapply DDS_drop with (xs := [])].
         simpl in *.
         apply IHl' in H0; auto.

--- a/systems/LiveLockServ.v
+++ b/systems/LiveLockServ.v
@@ -2119,6 +2119,7 @@ Section LockServ.
   Proof using.
     intros.
     pose proof (@clients_move_way_up_in_queue n 0 c s).
+    pose proof (Nat.le_0_l n).
     repeat concludes. conclude_using ltac:(intuition; congruence).
     eapply eventually_monotonic_simple; [|eauto].
     intros. simpl in *. intuition.

--- a/systems/SeqNumCorrect.v
+++ b/systems/SeqNumCorrect.v
@@ -50,6 +50,8 @@ Section SeqNumCorrect.
       + specialize (IHl n0 l0). apply IHl; auto.
   Qed.
 
+  Unset Regular Subst Tactic.
+  
   Lemma processPackets_nums_unique :
     forall n l n' l' p p',
       processPackets n l = (n', l') ->
@@ -70,6 +72,7 @@ Section SeqNumCorrect.
       + apply IHl with n0 l0 p p'; intuition.
   Qed.
 
+  Set Regular Subst Tactic.
   
   Lemma processPackets_seq_eq :
     forall n l n' l' x y,


### PR DESCRIPTION
I haven't yet done anything with Travis (which will still build against 8.5) - depending on the future of Coq 8.5 support, I suggest either switching it to build on 8.5, or building it against both 8.5 and 8.6.