### PR TITLE
Work around anomaly that only shows up in Coq trunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
       - aspcud
 env:
   matrix:
-    - DOWNSTREAM=none COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
+    - DOWNSTREAM=none COQ_VERSION=8.5.3 SSREFLECT_VERSION=1.6
     - DOWNSTREAM=verdi-raft VERDI_RAFT_BRANCH=master COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
 before_install:
   - openssl aes-256-cbc -K $encrypted_130bc391cda8_key -iv $encrypted_130bc391cda8_iv -in .travis/travis_rsa.enc -out .travis/travis_rsa -d

--- a/core/PartialMapSimulations.v
+++ b/core/PartialMapSimulations.v
@@ -580,7 +580,7 @@ rewrite pt_map_msg_update2 /= filterMap_app /=.
 case H_m': (pt_map_msg _) => [m'|]; first by rewrite H_m' in H_m.
 rewrite -app_nil_end.
 set f1 := update2 _ _ _ _ _.
-set f2 := fun _ _ => _.
+set f2 := fun _ _ => _ _.
 have H_eq_f: f1 = f2.
   rewrite /f1 /f2 {f1 f2}.
   apply functional_extensionality => src.
@@ -1286,7 +1286,7 @@ invcs H_step.
   split => //.
   rewrite /pt_map_odnet /= collate_pt_map_update2_eq H_ms /=.
   set nwP1 := update2 _ _ _ _ _.
-  set nwP2 := fun _ _ => _.
+  set nwP2 := fun _ _ => _ _.
   set nwS1 := fun _ => _.
   set nwS2 := fun _ => _.
   have H_eq_s: nwS1 = nwS2.

--- a/opam
+++ b/opam
@@ -15,8 +15,8 @@ build: [
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Verdi'" ]
 depends: [
-  "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.6" & < "1.7~") | (= "dev")}
+  "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
   "InfSeqExt" {= "dev"}
   "StructTact" {= "dev"}
 ]


### PR DESCRIPTION
Previously, Verdi wouldn't build using `coq.dev` from OPAM because of a "Non-functional construction" anomaly. This is probably a Coq bug, but fortunately the workaround (this PR) is easy and still builds with Coq 8.6 and 8.6.dev.