### PR TITLE
Generalize ghost sims

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 env:
   matrix:
     - DOWNSTREAM=none COQ_VERSION=8.5.3 SSREFLECT_VERSION=1.6
-    - DOWNSTREAM=verdi-raft VERDI_RAFT_BRANCH=master COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
+    - DOWNSTREAM=verdi-raft VERDI_RAFT_BRANCH=updated-ghost-sims COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
 before_install:
   - openssl aes-256-cbc -K $encrypted_130bc391cda8_key -iv $encrypted_130bc391cda8_iv -in .travis/travis_rsa.enc -out .travis/travis_rsa -d
   - cp .travis/travis_rsa ~/.ssh

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ install: Makefile.coq
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq \
           -extra-phony 'distclean' 'clean' \
-	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES)))))'
+	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES))))) $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.vo.aux,$$(VFILES)))))'
 
 clean:
 	if [ -f Makefile.coq ]; then \

--- a/core/GhostSimulations.v
+++ b/core/GhostSimulations.v
@@ -11,7 +11,7 @@ Require Import mathcomp.ssreflect.ssreflect.
 
 Set Implicit Arguments.
 
-Class GhostFailureParams `(P : FailureParams) :=
+Class GhostMultiParams `(P : MultiParams) :=
   {
     ghost_data : Type;
     ghost_init : ghost_data ;
@@ -26,7 +26,7 @@ Section GhostVars.
 Context {base_params : BaseParams}.
 Context {multi_params : MultiParams base_params}.
 Context {failure_params : FailureParams multi_params}.
-Context {params : GhostFailureParams failure_params}.
+Context {ghost_params : GhostMultiParams multi_params}.
 
 Definition refined_net_handlers me src m st :=
   let '(out, st', ps) :=
@@ -34,15 +34,14 @@ Definition refined_net_handlers me src m st :=
   (out, (ghost_net_handlers me src m st, st'), ps).
 
 Definition refined_input_handlers me inp st :=
-  let '(out, st', ps) :=
-      input_handlers me inp (snd st) in
+  let '(out, st', ps) := input_handlers me inp (snd st) in
   (out, (ghost_input_handlers me inp st, st'), ps).
-
-Definition refined_reboot (st : ghost_data * data) :=
-  (fst st , reboot (snd st)).
 
 Definition refined_init_handlers (n : name) : ghost_data * data :=
   (ghost_init, init_handlers n).
+
+Definition refined_reboot (st : ghost_data * data) :=
+  (fst st , reboot (snd st)).
 
 Instance refined_base_params : BaseParams :=
   {
@@ -301,7 +300,7 @@ Qed.
 
 End GhostVars.
 
-Class MsgGhostFailureParams `(P : FailureParams) :=
+Class MsgGhostMultiParams `(P : MultiParams) :=
   {
     ghost_msg : Type;
     ghost_msg_eq_dec : forall x y : ghost_msg, {x = y} + {x <> y} ;
@@ -315,20 +314,18 @@ Section MsgGhostVars.
 Context {base_params : BaseParams}.
 Context {multi_params : MultiParams base_params}.
 Context {failure_params : FailureParams multi_params}.
-Context {params : MsgGhostFailureParams failure_params}.
+Context {msg_ghost_params : MsgGhostMultiParams multi_params}.
 
 Definition add_ghost_msg (me : name) (st : data) (ps : list (name * msg)) :
                                                     list (name * (ghost_msg * msg)) :=
   map (fun m => (fst m, (write_ghost_msg me st, snd m))) ps.
 
 Definition mgv_refined_net_handlers me src (m : ghost_msg * msg) st :=
-  let '(out, st', ps) :=
-      net_handlers me src (snd m) st in
+  let '(out, st', ps) := net_handlers me src (snd m) st in
   (out, st', add_ghost_msg me st' ps).
 
 Definition mgv_refined_input_handlers me inp st :=
-  let '(out, st', ps) :=
-      input_handlers me inp st in
+  let '(out, st', ps) := input_handlers me inp st in
   (out, st', add_ghost_msg me st' ps).
 
 Definition mgv_msg_eq_dec :
@@ -599,8 +596,8 @@ Proof using.
 Qed.
 
 End MsgGhostVars.
-Arguments deghost_packet /_ _ _ _ _.
-Arguments ghost_packet /_ _ _ _ _.
+Arguments deghost_packet /_ _ _ _.
+Arguments ghost_packet /_ _ _ _.
 
-Arguments mgv_deghost_packet /_ _ _ _ _.
-Arguments mgv_ghost_packet /_ _ _ _ _.
+Arguments mgv_deghost_packet /_ _ _ _.
+Arguments mgv_ghost_packet /_ _ _ _.

--- a/lib/Maps.v
+++ b/lib/Maps.v
@@ -86,8 +86,8 @@ Module PTree <: TREE.
     | Leaf : tree A
     | Node : tree A -> option A -> tree A -> tree A.
 
-  Arguments Leaf [A].
-  Arguments Node [A].
+  Implicit Arguments Leaf [A].
+  Implicit Arguments Node [A].
   Scheme tree_ind := Induction for tree Sort Prop.
 
   Definition t := tree.

--- a/lib/Maps.v
+++ b/lib/Maps.v
@@ -46,32 +46,32 @@ Set Implicit Arguments.
 (** * The abstract signatures of trees *)
 
 Module Type TREE.
-  Variable elt: Type.
-  Variable elt_eq: forall (a b: elt), {a = b} + {a <> b}.
-  Variable t: Type -> Type.
-  Variable empty: forall (A: Type), t A.
-  Variable get: forall (A: Type), elt -> t A -> option A.
-  Variable set: forall (A: Type), elt -> A -> t A -> t A.
-  Variable remove: forall (A: Type), elt -> t A -> t A.
+  Parameter elt: Type.
+  Parameter elt_eq: forall (a b: elt), {a = b} + {a <> b}.
+  Parameter t: Type -> Type.
+  Parameter empty: forall (A: Type), t A.
+  Parameter get: forall (A: Type), elt -> t A -> option A.
+  Parameter set: forall (A: Type), elt -> A -> t A -> t A.
+  Parameter remove: forall (A: Type), elt -> t A -> t A.
 
   (** The ``good variables'' properties for trees, expressing
     commutations between [get], [set] and [remove]. *)
-  Hypothesis gempty:
+  Parameter gempty:
     forall (A: Type) (i: elt), get i (empty A) = None.
-  Hypothesis gss:
+  Parameter gss:
     forall (A: Type) (i: elt) (x: A) (m: t A), get i (set i x m) = Some x.
-  Hypothesis gso:
+  Parameter gso:
     forall (A: Type) (i j: elt) (x: A) (m: t A),
     i <> j -> get i (set j x m) = get i m.
-  Hypothesis gsspec:
+  Parameter gsspec:
     forall (A: Type) (i j: elt) (x: A) (m: t A),
     get i (set j x m) = if elt_eq i j then Some x else get i m.
-  Hypothesis grs:
+  Parameter grs:
     forall (A: Type) (i: elt) (m: t A), get i (remove i m) = None.
-  Hypothesis gro:
+  Parameter gro:
     forall (A: Type) (i j: elt) (m: t A),
     i <> j -> get i (remove j m) = get i m.
-  Hypothesis grspec:
+  Parameter grspec:
     forall (A: Type) (i j: elt) (m: t A),
     get i (remove j m) = if elt_eq i j then None else get i m.
 End TREE.
@@ -86,8 +86,8 @@ Module PTree <: TREE.
     | Leaf : tree A
     | Node : tree A -> option A -> tree A -> tree A.
 
-  Implicit Arguments Leaf [A].
-  Implicit Arguments Node [A].
+  Arguments Leaf [A].
+  Arguments Node [A].
   Scheme tree_ind := Induction for tree Sort Prop.
 
   Definition t := tree.
@@ -251,10 +251,10 @@ Module PTree <: TREE.
 End PTree.
 
 Module Type INDEXED_TYPE.
-  Variable t: Type.
-  Variable index: t -> positive.
-  Hypothesis index_inj: forall (x y: t), index x = index y -> x = y.
-  Variable eq: forall (x y: t), {x = y} + {x <> y}.
+  Parameter t: Type.
+  Parameter index: t -> positive.
+  Parameter index_inj: forall (x y: t), index x = index y -> x = y.
+  Parameter eq: forall (x y: t), {x = y} + {x <> y}.
 End INDEXED_TYPE.
 
 
@@ -298,8 +298,8 @@ End NIndexed.
 (** * An implementation of maps over any type with decidable equality *)
 
 Module Type EQUALITY_TYPE.
-  Variable t: Type.
-  Variable eq: forall (x y: t), {x = y} + {x <> y}.
+  Parameter t: Type.
+  Parameter eq: forall (x y: t), {x = y} + {x <> y}.
 End EQUALITY_TYPE.
 
 Module ETree(X: EQUALITY_TYPE) <: TREE.


### PR DESCRIPTION
Remove needless restriction of ghost simulation type classes to `FailureParams`. Fix some warnings.