### PR TITLE
compatibility with both 8.6.1 and 8.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 _CoqProject
 Makefile.coq
 Makefile.coq.bak
+Makefile.coq.conf
 *~
 .coq-native/
 *.aux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ addons:
       - aspcud
 env:
   matrix:
-    - DOWNSTREAM=none COQ_VERSION=8.5.3 SSREFLECT_VERSION=1.6
-    - DOWNSTREAM=verdi-raft COQ_VERSION=8.6 SSREFLECT_VERSION=1.6.1
-    - DOWNSTREAM=none COQ_VERSION=8.6.1 SSREFLECT_VERSION=1.6.1
+    - DOWNSTREAM=verdi-raft COQ_VERSION=8.6.1 SSREFLECT_VERSION=1.6.1
+    - DOWNSTREAM=none COQ_VERSION=8.7.0 SSREFLECT_VERSION=1.6.2
 before_install:
   - openssl aes-256-cbc -K $encrypted_130bc391cda8_key -iv $encrypted_130bc391cda8_iv -in .travis/travis_rsa.enc -out .travis/travis_rsa -d
   - cp .travis/travis_rsa ~/.ssh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # sets COQVERSION
 include Makefile.detect-coq-version
 
-ifeq (,$(filter $(COQVERSION),8.5 8.6 8.7 trunk))
-$(error "Verdi is only compatible with Coq version 8.5 or later")
+ifeq (,$(filter $(COQVERSION),8.6 8.7 trunk))
+$(error "Verdi is only compatible with Coq version 8.6.1 or later")
 endif
 
 COQPROJECT_EXISTS := $(wildcard _CoqProject)
@@ -28,13 +28,11 @@ install: Makefile.coq
 	$(MAKE) -f Makefile.coq install
 
 Makefile.coq: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq \
-          -extra-phony 'distclean' 'clean' \
-	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES))))) $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.vo.aux,$$(VFILES)))))'
+	coq_makefile -f _CoqProject -o Makefile.coq
 
 clean:
 	if [ -f Makefile.coq ]; then \
-	  $(MAKE) -f Makefile.coq distclean; fi
+	  $(MAKE) -f Makefile.coq cleanall; fi
 	rm -f Makefile.coq
 
 lint:

--- a/extraction/ExtrOcamlBasicExt.v
+++ b/extraction/ExtrOcamlBasicExt.v
@@ -1,2 +1,4 @@
+Require Extraction.
+
 Extract Inlined Constant fst => "fst".
 Extract Inlined Constant snd => "snd".

--- a/extraction/ExtrOcamlBool.v
+++ b/extraction/ExtrOcamlBool.v
@@ -1,4 +1,5 @@
 Require Import Bool.
+Require Extraction.
 
 Extract Inlined Constant negb => "not".
 

--- a/extraction/ExtrOcamlDiskOp.v
+++ b/extraction/ExtrOcamlDiskOp.v
@@ -1,3 +1,4 @@
 Require Import Verdi.Net.
+Require Extraction.
 
 Extract Inductive disk_op => "DiskOpShim.disk_op" ["DiskOpShim.Append" "DiskOpShim.Write" "DiskOpShim.Delete"].

--- a/extraction/ExtrOcamlFinInt.v
+++ b/extraction/ExtrOcamlFinInt.v
@@ -1,4 +1,5 @@
 Require Import StructTact.Fin.
+Require Extraction.
 
 Extract Inlined Constant fin => int.
 

--- a/extraction/ExtrOcamlList.v
+++ b/extraction/ExtrOcamlList.v
@@ -1,4 +1,5 @@
 Require Import List.
+Require Extraction.
 
 Extract Inlined Constant length => "List.length".
 Extract Inlined Constant app => "List.append".

--- a/extraction/ExtrOcamlNatIntExt.v
+++ b/extraction/ExtrOcamlNatIntExt.v
@@ -1,5 +1,6 @@
 Require Import PeanoNat.
 Require Import Ascii.
+Require Extraction.
 
 Extract Inlined Constant Nat.max => "Pervasives.max".
 Extract Inlined Constant Nat.min => "Pervasives.min".

--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ build: [
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Verdi'" ]
 depends: [
-  "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))}
+  "coq" {((>= "8.6.1" & < "8.7~") | (>= "8.7" & < "8.8~"))}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.7~"}
   "InfSeqExt" {= "dev"}
   "StructTact" {= "dev"}


### PR DESCRIPTION
Stay dependent on `coq-mathcomp-ssreflect` to support Coq 8.7.0 but stay compatible with 8.6.1 a while longer.