### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/core/PartialExtendedMapSimulations.v
+++ b/core/PartialExtendedMapSimulations.v
@@ -154,7 +154,7 @@ case => {net net' tr}.
     destruct (net_handlers (pDst p0) (pSrc p0) (pBody p0) (pt_ext_map_data (nwState net (pDst p)) (pDst p))) eqn:?.
     destruct p1 as [out' d'].
     exists [(pDst p0, inr out')].
-    apply StepAsync_deliver with (xs := filterMap pt_map_packet ms) (ys := filterMap pt_map_packet ms') (d0 := pt_ext_map_data d (pDst p)) (l1 := filterMap pt_map_name_msg l).
+    apply @StepAsync_deliver with (xs := filterMap pt_map_packet ms) (ys := filterMap pt_map_packet ms') (d := pt_ext_map_data d (pDst p)) (l := filterMap pt_map_name_msg l).
     * rewrite /= H_eq filterMap_app /=.
       case H_p: (pt_map_packet _) => [p1|]; last by rewrite H_p in Heqo.
       by rewrite H_p in Heqo; injection Heqo => H_eq_p; rewrite H_eq_p.

--- a/systems/LogCorrect.v
+++ b/systems/LogCorrect.v
@@ -299,10 +299,10 @@ Section LogCorrect.
       rewrite revert_send.
       assert (revert_packet : do_pDst p = pDst (revertPacket p)) by reflexivity.
       rewrite revert_packet in *.
-      apply StepFailure_deliver with (xs0 := map revertPacket xs)
-                                     (ys0 := map revertPacket ys)
-                                     (d0 := log_data d)
-                                     (l0 := l).
+      apply @StepFailure_deliver with (xs := map revertPacket xs)
+                                     (ys := map revertPacket ys)
+                                     (d := log_data d)
+                                     (l := l).
       + reflexivity.
       + assumption.
       + simpl.
@@ -319,7 +319,7 @@ Section LogCorrect.
       simpl.
       repeat rewrite map_app.
       rewrite revert_send.
-      apply StepFailure_input with (d0 := log_data d) (l0 := l).
+      apply @StepFailure_input with (d := log_data d) (l := l).
       + assumption.
       + unfold log_input_handlers, log_handler_result in *.
         do 2 break_let.
@@ -331,9 +331,9 @@ Section LogCorrect.
     - unfold revertLogNetwork.
       simpl. find_rewrite.
       rewrite map_app. simpl.
-      apply StepFailure_drop with (xs0 := map revertPacket xs)
-                                  (p0 := revertPacket p)
-                                  (ys0 := map revertPacket ys).
+      apply @StepFailure_drop with (xs := map revertPacket xs)
+                                  (p := revertPacket p)
+                                  (ys := map revertPacket ys).
       + reflexivity.
       + rewrite map_app. reflexivity.
     - unfold revertLogNetwork.
@@ -346,7 +346,7 @@ Section LogCorrect.
       + reflexivity.
       + reflexivity.
     - constructor.
-    - apply StepFailure_reboot with (h0 := h).
+    - apply @StepFailure_reboot with (h := h).
       + assumption.
       + reflexivity.
       + unfold revertLogNetwork. simpl.


### PR DESCRIPTION
Should be backwards compatible.